### PR TITLE
fix: only include dist directory when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "react-currency-input-field",
   "version": "0.4.0",
   "description": "React input field component for currency and numbers",
+  "files": [
+    "dist/**/*"
+  ],
   "main": "dist/index.js",
   "homepage": "https://cchanxzy.github.io/react-currency-input-field",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -17,11 +17,11 @@ Features:
 
 ### Install
 
-`npm install --save-dev react-currency-input-field`
+`npm install react-currency-input-field`
 
 or
 
-`yarn add -D react-currency-input-field`
+`yarn add react-currency-input-field`
 
 ### Usage
 


### PR DESCRIPTION
Only include `dist` directory when publishing to NPM