### PR TITLE
feat: allow name to be added to prop and onChange callback

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,11 +30,12 @@ import CurrencyInput from 'react-currency-input-field'
 
 <CurrencyInput
   id="input-example"
+  name="input-name"
   placeholder="£1,000"
   defaultValue={1000}
   allowDecimals={true}
   decimalsLimit={2}
-  onChange={() => {}}
+  onChange={(value, name) => {process(value, name)}}
 />
 ```
 

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -5,6 +5,7 @@ import { checkIsValidNumber, cleanValue, formatValue } from './utilities';
 export const CurrencyInput: FC<CurrencyInputProps> = ({
   allowDecimals = true,
   id,
+  name,
   className,
   decimalsLimit = 2,
   defaultValue,
@@ -26,7 +27,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
     const valueOnly = cleanValue(value, allowDecimals, decimalsLimit, prefix);
 
     if (!valueOnly) {
-      onChange(null);
+      onChange(null, name);
       return setStateValue('');
     }
 
@@ -34,18 +35,20 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
       setStateValue(formatValue(valueOnly, prefix));
     }
 
-    onChange(Number(valueOnly));
+    onChange(Number(valueOnly), name);
   };
 
   return (
     <input
       type="string"
       id={id}
+      name={name}
       className={className}
       onChange={processChange}
       onFocus={onFocus}
       placeholder={placeholder}
       value={stateValue}
+      pattern="[0-9]*"
     />
   );
 };

--- a/src/components/__tests__/CurrencyInput.test.tsx
+++ b/src/components/__tests__/CurrencyInput.test.tsx
@@ -5,16 +5,24 @@ import CurrencyInput from '../CurrencyInput';
 const id = 'validationCustom01';
 const className = 'form-control';
 const placeholder = '£1,000';
+const name = 'inputName';
 
 describe('<CurrencyInput /> component', () => {
   it('Renders without error', () => {
     const view = shallow(
-      <CurrencyInput id={id} placeholder={placeholder} className={className} onChange={jest.fn()} />
+      <CurrencyInput
+        id={id}
+        name={name}
+        placeholder={placeholder}
+        className={className}
+        onChange={jest.fn()}
+      />
     );
     const input = view.find(`#${id}`);
-    expect(input).toMatchSnapshot();
 
+    expect(input).toMatchSnapshot();
     expect(input.prop('id')).toBe(id);
+    expect(input.prop('name')).toBe(name);
     expect(input.prop('placeholder')).toBe(placeholder);
     expect(input.prop('className')).toBe(className);
   });
@@ -32,8 +40,8 @@ describe('<CurrencyInput /> component', () => {
       />
     );
     const input = view.find(`#${id}`);
-    expect(input).toMatchSnapshot();
 
+    expect(view.html()).toMatchSnapshot();
     expect(input.prop('id')).toBe(id);
     expect(input.prop('value')).toBe('£1,234.56');
     expect(input.prop('className')).toBe(className);
@@ -60,14 +68,14 @@ describe('<CurrencyInput /> component', () => {
     const view = shallow(<CurrencyInput id={id} prefix="£" onChange={onChangeSpy} />);
     view.find(`#${id}`).simulate('change', { target: { value: '100' } });
 
-    expect(onChangeSpy).toBeCalledWith(100);
+    expect(onChangeSpy).toBeCalledWith(100, undefined);
   });
 
   it('should not allow string value change', () => {
     const onChangeSpy = jest.fn();
     const view = shallow(<CurrencyInput id={id} prefix="£" onChange={onChangeSpy} />);
     view.find(`#${id}`).simulate('change', { target: { value: 'aakoa' } });
-    expect(onChangeSpy).toBeCalledWith(NaN);
+    expect(onChangeSpy).toBeCalledWith(NaN, undefined);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('');
@@ -75,12 +83,19 @@ describe('<CurrencyInput /> component', () => {
 
   it('should allow empty value', () => {
     const onChangeSpy = jest.fn();
-    const view = shallow(<CurrencyInput id={id} prefix="£" onChange={onChangeSpy} />);
+    const view = shallow(<CurrencyInput id={id} name={name} prefix="£" onChange={onChangeSpy} />);
     view.find(`#${id}`).simulate('change', { target: { value: '' } });
-    expect(onChangeSpy).toBeCalledWith(null);
+    expect(onChangeSpy).toBeCalledWith(null, name);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('');
+  });
+
+  it('should callback name as second parameter if name prop provided', () => {
+    const onChangeSpy = jest.fn();
+    const view = shallow(<CurrencyInput id={id} name={name} prefix="£" onChange={onChangeSpy} />);
+    view.find(`#${id}`).simulate('change', { target: { value: '£123' } });
+    expect(onChangeSpy).toBeCalledWith(123, name);
   });
 
   describe('decimals', () => {
@@ -90,7 +105,7 @@ describe('<CurrencyInput /> component', () => {
         <CurrencyInput allowDecimals={true} id={id} prefix="£" onChange={onChangeSpy} />
       );
       view.find(`#${id}`).simulate('change', { target: { value: '£1,234.56' } });
-      expect(onChangeSpy).toBeCalledWith(1234.56);
+      expect(onChangeSpy).toBeCalledWith(1234.56, undefined);
 
       const updatedView = view.update();
       expect(updatedView.find(`#${id}`).prop('value')).toBe('£1,234.56');
@@ -102,7 +117,7 @@ describe('<CurrencyInput /> component', () => {
         <CurrencyInput allowDecimals={false} id={id} prefix="£" onChange={onChangeSpy} />
       );
       view.find(`#${id}`).simulate('change', { target: { value: '£1,234.56' } });
-      expect(onChangeSpy).toBeCalledWith(1234);
+      expect(onChangeSpy).toBeCalledWith(1234, undefined);
 
       const updatedView = view.update();
       expect(updatedView.find(`#${id}`).prop('value')).toBe('£1,234');
@@ -114,7 +129,7 @@ describe('<CurrencyInput /> component', () => {
         <CurrencyInput id={id} decimalsLimit={3} prefix="£" onChange={onChangeSpy} />
       );
       view.find(`#${id}`).simulate('change', { target: { value: '£1,234.56789' } });
-      expect(onChangeSpy).toBeCalledWith(1234.567);
+      expect(onChangeSpy).toBeCalledWith(1234.567, undefined);
 
       const updatedView = view.update();
       expect(updatedView.find(`#${id}`).prop('value')).toBe('£1,234.567');

--- a/src/components/__tests__/__snapshots__/CurrencyInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/CurrencyInput.test.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<CurrencyInput /> component Renders with default value 1`] = `ShallowWrapper {}`;
+exports[`<CurrencyInput /> component Renders with default value 1`] = `"<input type=\\"string\\" id=\\"validationCustom01\\" class=\\"form-control\\" value=\\"£1,234.56\\" pattern=\\"[0-9]*\\"/>"`;
 
 exports[`<CurrencyInput /> component Renders without error 1`] = `ShallowWrapper {}`;

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -11,6 +11,11 @@ export interface CurrencyInputProps {
   id: string;
 
   /**
+   * Component name
+   */
+  name?: string;
+
+  /**
    * Class names
    */
   className?: string;
@@ -29,7 +34,7 @@ export interface CurrencyInputProps {
   /**
    * Handle change in value
    */
-  onChange: (value: number | null) => void;
+  onChange: (value: number | null, name?: string) => void;
 
   /**
    * Placeholder

--- a/src/examples/Example1.tsx
+++ b/src/examples/Example1.tsx
@@ -5,8 +5,8 @@ export const Example1: FC = () => {
   const limit = 1000;
   const prefix = '£';
 
-  const [errorMessage, setErrorMessage] = useState();
-  const [className, setClassName] = useState();
+  const [errorMessage, setErrorMessage] = useState('');
+  const [className, setClassName] = useState('');
 
   const validateValue = (value: number | null): void => {
     if (value === null) {
@@ -29,6 +29,7 @@ export const Example1: FC = () => {
           <label htmlFor="validationCustom01">Please enter a value (max £1,000)</label>
           <CurrencyInput
             id="validationCustom01"
+            name="input-1"
             defaultValue={999.99}
             className={`form-control ${className}`}
             onChange={validateValue}

--- a/src/examples/Example2.tsx
+++ b/src/examples/Example2.tsx
@@ -3,8 +3,8 @@ import { hot } from 'react-hot-loader';
 import CurrencyInput from '../components/CurrencyInput';
 
 export const Example2: FC = () => {
-  const [errorMessage, setErrorMessage] = useState();
-  const [className, setClassName] = useState();
+  const [errorMessage, setErrorMessage] = useState('');
+  const [className, setClassName] = useState('');
 
   const validateValue = (value: number | null): void => {
     if (value === null) {


### PR DESCRIPTION
Allow `name` as prop to be passed down to component, and in return will be the second param in the `onChange` callback.