### PR TITLE
chore: cache node_modules in build workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,11 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
         run: yarn
       - name: Build package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
         run: yarn
       - name: Build package

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -9,7 +9,7 @@
       [
         '@semantic-release/git',
         {
-          'assets': ['dist/**/*.{js,css}', 'CHANGELOG.md', 'package.json'],
+          'assets': ['CHANGELOG.md', 'package.json'],
           'message': "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
         },
       ],


### PR DESCRIPTION
cache `node_modules` to speed up workflow.