### PR TITLE
fix: artificial change to trigger version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-currency-input-field",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React <input /> component for formatting currency and numbers.",
   "files": [
     "dist/**/*"


### PR DESCRIPTION
Previous master build failed because I had once accidentally published v1.0.0 on NPM and cannot remove. So need to trigger another build to update to next version.