### PR TITLE
feat: add custom component support

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -4,6 +4,7 @@ import { checkIsValidNumber, cleanValue, formatValue, padTrimValue } from './uti
 
 export const CurrencyInput: FC<CurrencyInputProps> = ({
   allowDecimals = true,
+  as: is, // 'as' is a keyword in typescript
   id,
   name,
   className,
@@ -68,8 +69,10 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
     ? formatValue(String(value), turnOffSeparators, prefix)
     : undefined;
 
+  const AsElement = is || 'input';
+
   return (
-    <input
+    <AsElement
       type="text"
       inputMode="decimal"
       id={id}

--- a/src/components/CurrencyInputProps.ts
+++ b/src/components/CurrencyInputProps.ts
@@ -11,6 +11,12 @@ export type CurrencyInputProps = Overwrite<
     allowDecimals?: boolean;
 
     /**
+     * Component to render. Can either be a string e.g. 'input', or a component.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    as?: string | React.ComponentType<any> | React.ForwardRefExoticComponent<any>;
+
+    /**
      * Component id
      */
     id?: string;


### PR DESCRIPTION
Allows the use of custom components with the `as` prop.

closes https://github.com/cchanxzy/react-currency-input-field/issues/59