### PR TITLE
feat: add prop to disallow negative value

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Example if `fixedDecimalLength` was 2:
 | Name               | Type       | Default | Description                                                              |
 | ------------------ | ---------- | ------- | ------------------------------------------------------------------------ |
 | allowDecimals      | `boolean`  | `true`  | Allow decimals                                                           |
+| allowNegativeValue | `boolean`  | `true`  | Allow user to enter negative value                                       |
 | className          | `string`   |         | Class names                                                              |
 | decimalsLimit      | `number`   | `2`     | Limit length of decimals allowed                                         |
 | defaultValue       | `number`   |         | Default value                                                            |

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -10,6 +10,7 @@ import {
 
 export const CurrencyInput: FC<CurrencyInputProps> = ({
   allowDecimals = true,
+  allowNegativeValue = true,
   id,
   name,
   className,
@@ -52,6 +53,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
     groupSeparator,
     allowDecimals,
     decimalsLimit: decimalsLimit || fixedDecimalLength || 2,
+    allowNegativeValue,
     prefix,
   };
 

--- a/src/components/CurrencyInputProps.ts
+++ b/src/components/CurrencyInputProps.ts
@@ -13,6 +13,13 @@ export type CurrencyInputProps = Overwrite<
     allowDecimals?: boolean;
 
     /**
+     * Allow user to enter negative value
+     *
+     * Default = true
+     */
+    allowNegativeValue?: boolean;
+
+    /**
      * Component id
      */
     id?: string;

--- a/src/components/__tests__/CurrencyInput.test.tsx
+++ b/src/components/__tests__/CurrencyInput.test.tsx
@@ -388,5 +388,26 @@ describe('<CurrencyInput /> component', () => {
       const updatedView = view.update();
       expect(updatedView.find(`#${id}`).prop('value')).toBe('');
     });
+
+    it('should not allow negative value if allowNegativeValue is false', () => {
+      const view = shallow(
+        <CurrencyInput
+          id={id}
+          prefix="$"
+          onChange={onChangeSpy}
+          allowNegativeValue={false}
+          defaultValue={123}
+        />
+      );
+
+      const input = view.find(`#${id}`);
+      expect(input.prop('value')).toBe('$123');
+
+      input.simulate('change', { target: { value: '-$1234' } });
+      expect(onChangeSpy).toBeCalledWith('1234', undefined);
+
+      const updatedView = view.update();
+      expect(updatedView.find(`#${id}`).prop('value')).toBe('$1,234');
+    });
   });
 });

--- a/src/components/utils/__tests__/cleanValue.spec.ts
+++ b/src/components/utils/__tests__/cleanValue.spec.ts
@@ -104,5 +104,18 @@ describe('cleanValue', () => {
       });
       expect(value).toEqual('-99999.99');
     });
+
+    it('should handle not allow negative value if allowNegativeValue is false', () => {
+      const value = cleanValue({
+        value: '-£1,000',
+        decimalSeparator: '.',
+        groupSeparator: ',',
+        allowDecimals: true,
+        decimalsLimit: 2,
+        allowNegativeValue: false,
+        prefix: '£',
+      });
+      expect(value).toEqual('1000');
+    });
   });
 });

--- a/src/components/utils/cleanValue.ts
+++ b/src/components/utils/cleanValue.ts
@@ -7,6 +7,7 @@ type Props = {
   groupSeparator: string;
   allowDecimals: boolean;
   decimalsLimit: number;
+  allowNegativeValue?: boolean;
   prefix?: string;
 };
 
@@ -19,6 +20,7 @@ export const cleanValue = ({
   groupSeparator,
   allowDecimals,
   decimalsLimit,
+  allowNegativeValue = true,
   prefix,
 }: Props): string => {
   const isNegative = value.includes('-');
@@ -27,7 +29,7 @@ export const cleanValue = ({
   const withoutSeparators = removeSeparators(withoutPrefix, groupSeparator);
 
   const parsed = parseAbbrValue(withoutSeparators, decimalSeparator) || withoutSeparators;
-  const includeNegative = isNegative ? '-' : '';
+  const includeNegative = isNegative && allowNegativeValue ? '-' : '';
 
   if (String(parsed).includes(decimalSeparator)) {
     const [int, decimals] = withoutSeparators.split(decimalSeparator);


### PR DESCRIPTION
Added new prop `allowNegativeValue` so you can disable user from entering a negative value.

Issue: #66 