### PR TITLE
fix: prefix 0 value

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -66,7 +66,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
   const onFocus = (): number => (stateValue ? stateValue.length : 0);
 
   const processChange = ({ target: { value } }: React.ChangeEvent<HTMLInputElement>): void => {
-    const valueOnly = cleanValue({ value, ...cleanValueOptions });
+    const valueOnly = cleanValue({ value: String(value), ...cleanValueOptions });
 
     if (!valueOnly) {
       onChange && onChange(undefined, name);
@@ -109,9 +109,8 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
     onChange && onChange(newValue, name);
   };
 
-  const formattedPropsValue = value
-    ? formatValue({ value: String(value), ...formatValueOptions })
-    : value;
+  const formattedPropsValue =
+    value !== undefined ? formatValue({ value: String(value), ...formatValueOptions }) : undefined;
 
   return (
     <input

--- a/src/components/__tests__/CurrencyInput.test.tsx
+++ b/src/components/__tests__/CurrencyInput.test.tsx
@@ -73,6 +73,22 @@ describe('<CurrencyInput /> component', () => {
     expect(onChangeSpy).toBeCalledWith('100', undefined);
   });
 
+  it('should prefix 0 value', () => {
+    const view = shallow(
+      <CurrencyInput id={id} name={name} prefix="£" value={0} onChange={onChangeSpy} />
+    );
+    expect(view.find(`#${id}`).prop('value')).toBe('£0');
+  });
+
+  it('should allow 0 value on change', () => {
+    const view = shallow(<CurrencyInput id={id} name={name} prefix="£" onChange={onChangeSpy} />);
+    view.find(`#${id}`).simulate('change', { target: { value: 0 } });
+    expect(onChangeSpy).toBeCalledWith('0', name);
+
+    const updatedView = view.update();
+    expect(updatedView.find(`#${id}`).prop('value')).toBe('£0');
+  });
+
   it('should allow empty value', () => {
     const view = shallow(<CurrencyInput id={id} name={name} prefix="£" onChange={onChangeSpy} />);
     view.find(`#${id}`).simulate('change', { target: { value: '' } });


### PR DESCRIPTION
Found a bug where `0` was not being prefixed.