### PR TITLE
fix: removed whitespace as possible valid number

### DIFF
--- a/src/components/__tests__/CurrencyInput-separators.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-separators.spec.tsx
@@ -89,4 +89,21 @@ describe('<CurrencyInput /> component > separators', () => {
       )
     ).toThrow('groupSeparator cannot be a number');
   });
+
+  it('whitespaces should not be considered a number when used as separator', () => {
+    const view = shallow(
+      <CurrencyInput
+        id={id}
+        name={name}
+        prefix="£"
+        decimalSeparator="."
+        groupSeparator={' '}
+        onChange={onChangeSpy}
+        defaultValue={10000}
+      />
+    );
+
+    const input = view.find(`#${id}`);
+    expect(input.prop('value')).toBe('£10 000');
+  });
 });

--- a/src/components/utils/checkIsValidNumber.ts
+++ b/src/components/utils/checkIsValidNumber.ts
@@ -1,5 +1,5 @@
 export const checkIsValidNumber = (input: string): boolean => {
-  if (Number(input) < 0 || Number.isNaN(Number(input))) {
+  if (input === ' ' || Number(input) < 0 || Number.isNaN(Number(input))) {
     return false;
   }
 


### PR DESCRIPTION
Possible fix for #76 

I changed the `checkIsValidNumber` function in this case, as I don't think a whitespace should be considered a valid number. If it makes more sense, I could move this "bail" to the component as well.