### PR TITLE
fix: handle values before prefix

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useRef } from 'react';
+import React, { FC, useState, useEffect, useRef } from 'react';
 import { CurrencyInputProps } from './CurrencyInputProps';
 import { isNumber, cleanValue, fixedDecimalValue, formatValue, padTrimValue } from './utils';
 
@@ -56,11 +56,14 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
       ? formatValue({ value: String(defaultValue), ...formatValueOptions })
       : '';
   const [stateValue, setStateValue] = useState(_defaultValue);
+  const [cursor, setCursor] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const onFocus = (): number => (stateValue ? stateValue.length : 0);
 
-  const processChange = ({ target: { value } }: React.ChangeEvent<HTMLInputElement>): void => {
+  const processChange = ({
+    target: { value, selectionStart },
+  }: React.ChangeEvent<HTMLInputElement>): void => {
     const valueOnly = cleanValue({ value: String(value), ...cleanValueOptions });
 
     if (!valueOnly) {
@@ -80,6 +83,13 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
     }
 
     const formattedValue = formatValue({ value: valueOnly, ...formatValueOptions });
+
+    /* istanbul ignore next */
+    if (selectionStart) {
+      const cursor = selectionStart + (formattedValue.length - value.length) || 1;
+      setCursor(cursor);
+    }
+
     setStateValue(formattedValue);
 
     onChange && onChange(valueOnly, name);
@@ -103,6 +113,13 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
     setStateValue(formattedValue);
     onChange && onChange(newValue, name);
   };
+
+  /* istanbul ignore next */
+  useEffect(() => {
+    if (inputRef && inputRef.current) {
+      inputRef.current.setSelectionRange(cursor, cursor);
+    }
+  }, [cursor, inputRef]);
 
   const formattedPropsValue =
     value !== undefined ? formatValue({ value: String(value), ...formatValueOptions }) : undefined;

--- a/src/components/utils/__tests__/cleanValue.spec.ts
+++ b/src/components/utils/__tests__/cleanValue.spec.ts
@@ -2,98 +2,139 @@ import { cleanValue } from '../cleanValue';
 
 describe('cleanValue', () => {
   it('should remove group separator in string', () => {
-    const value = cleanValue({
-      value: '1,000,000',
-    });
-    expect(value).toEqual('1000000');
+    expect(
+      cleanValue({
+        value: '1,000,000',
+      })
+    ).toEqual('1000000');
   });
 
   it('should handle period decimal separator in string', () => {
-    const value = cleanValue({
-      value: '1.000.000,12',
-      decimalSeparator: ',',
-      groupSeparator: '.',
-    });
-    expect(value).toEqual('1000000,12');
+    expect(
+      cleanValue({
+        value: '1.000.000,12',
+        decimalSeparator: ',',
+        groupSeparator: '.',
+      })
+    ).toEqual('1000000,12');
   });
 
   it('should remove prefix', () => {
-    const value = cleanValue({
-      value: '£1000000',
-      prefix: '£',
-    });
-    expect(value).toEqual('1000000');
+    expect(
+      cleanValue({
+        value: '£1000000',
+        prefix: '£',
+      })
+    ).toEqual('1000000');
   });
 
   it('should remove extra decimals', () => {
-    const value = cleanValue({
-      value: '100.0000',
-    });
-    expect(value).toEqual('100.00');
+    expect(
+      cleanValue({
+        value: '100.0000',
+      })
+    ).toEqual('100.00');
   });
 
   it('should remove decimals if not allowed', () => {
-    const value = cleanValue({
-      value: '100.0000',
-      allowDecimals: false,
-      decimalsLimit: 0,
-    });
-    expect(value).toEqual('100');
+    expect(
+      cleanValue({
+        value: '100.0000',
+        allowDecimals: false,
+        decimalsLimit: 0,
+      })
+    ).toEqual('100');
   });
 
   it('should include decimals if allowed', () => {
-    const value = cleanValue({
-      value: '100.123',
-      allowDecimals: true,
-      decimalsLimit: 0,
-    });
-    expect(value).toEqual('100.123');
+    expect(
+      cleanValue({
+        value: '100.123',
+        allowDecimals: true,
+        decimalsLimit: 0,
+      })
+    ).toEqual('100.123');
   });
 
   it('should format value', () => {
-    const value = cleanValue({
-      value: '£1,234,567.89',
-      prefix: '£',
-    });
-    expect(value).toEqual('1234567.89');
+    expect(
+      cleanValue({
+        value: '£1,234,567.89',
+        prefix: '£',
+      })
+    ).toEqual('1234567.89');
   });
 
   describe('negative values', () => {
     it('should handle negative value', () => {
-      const value = cleanValue({
-        value: '-£1,000',
-        decimalSeparator: '.',
-        groupSeparator: ',',
-        allowDecimals: true,
-        decimalsLimit: 2,
-        prefix: '£',
-      });
-      expect(value).toEqual('-1000');
+      expect(
+        cleanValue({
+          value: '-£1,000',
+          decimalSeparator: '.',
+          groupSeparator: ',',
+          allowDecimals: true,
+          decimalsLimit: 2,
+          prefix: '£',
+        })
+      ).toEqual('-1000');
     });
 
     it('should handle negative value with decimal', () => {
-      const value = cleanValue({
-        value: '-£99,999.99',
-        decimalSeparator: '.',
-        groupSeparator: ',',
-        allowDecimals: true,
-        decimalsLimit: 2,
-        prefix: '£',
-      });
-      expect(value).toEqual('-99999.99');
+      expect(
+        cleanValue({
+          value: '-£99,999.99',
+          decimalSeparator: '.',
+          groupSeparator: ',',
+          allowDecimals: true,
+          decimalsLimit: 2,
+          prefix: '£',
+        })
+      ).toEqual('-99999.99');
     });
 
     it('should handle not allow negative value if allowNegativeValue is false', () => {
-      const value = cleanValue({
-        value: '-£1,000',
-        decimalSeparator: '.',
-        groupSeparator: ',',
-        allowDecimals: true,
-        decimalsLimit: 2,
-        allowNegativeValue: false,
-        prefix: '£',
-      });
-      expect(value).toEqual('1000');
+      expect(
+        cleanValue({
+          value: '-£1,000',
+          decimalSeparator: '.',
+          groupSeparator: ',',
+          allowDecimals: true,
+          decimalsLimit: 2,
+          allowNegativeValue: false,
+          prefix: '£',
+        })
+      ).toEqual('1000');
     });
+  });
+
+  it('should handle values placed before prefix', () => {
+    expect(
+      cleanValue({
+        value: '2£1',
+        prefix: '£',
+      })
+    ).toEqual('12');
+
+    expect(
+      cleanValue({
+        value: '-2£1',
+        prefix: '£',
+      })
+    ).toEqual('-12');
+
+    expect(
+      cleanValue({
+        value: '2-£1',
+        prefix: '£',
+      })
+    ).toEqual('-12');
+
+    expect(
+      cleanValue({
+        value: '2-£1.99',
+        prefix: '£',
+        decimalsLimit: 5,
+      })
+    ).toEqual('-1.992');
   });
 });

--- a/src/components/utils/cleanValue.ts
+++ b/src/components/utils/cleanValue.ts
@@ -26,8 +26,8 @@ export const cleanValue = ({
 }: Props): string => {
   const isNegative = value.includes('-');
 
-  const withoutNegative = isNegative ? value.replace('-', '') : value;
-  const withoutPrefix = prefix ? withoutNegative.replace(prefix, '') : withoutNegative;
+  const [prefixWithValue, preValue] = RegExp(`(\\d+)-?${prefix}`).exec(value) || [];
+  const withoutPrefix = prefix ? value.replace(prefixWithValue, '').concat(preValue) : value;
   const withoutSeparators = removeSeparators(withoutPrefix, groupSeparator);
   const withoutInvalidChars = removeInvalidChars(withoutSeparators, [
     groupSeparator,


### PR DESCRIPTION
It should now better handle values before the prefix, and cursor should not jump around if you input values proceeding another value.

Issue #78 