### PR TITLE
Escape prefix before using in Regex - fixes #84

### DIFF
--- a/src/components/utils/cleanValue.ts
+++ b/src/components/utils/cleanValue.ts
@@ -26,7 +26,8 @@ export const cleanValue = ({
 }: Props): string => {
   const isNegative = value.includes('-');
 
-  const [prefixWithValue, preValue] = RegExp(`(\\d+)-?${prefix}`).exec(value) || [];
+  const escapedPrefix = prefix?.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+  const [prefixWithValue, preValue] = RegExp(`(\\d+)-?${escapedPrefix}`).exec(value) || [];
   const withoutPrefix = prefix ? value.replace(prefixWithValue, '').concat(preValue) : value;
   const withoutSeparators = removeSeparators(withoutPrefix, groupSeparator);
   const withoutInvalidChars = removeInvalidChars(withoutSeparators, [


### PR DESCRIPTION
Fix for issue #84, escapes the prefix before passing it to the regex as putting a `$` straight into a regex causes unexpected results.
