### PR TITLE
refactor: split out webpack configs

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -28,5 +28,5 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: dist
+          FOLDER: demo/examples
           CLEAN: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 .vscode
 dist
+demo/examples

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   "types": "dist/index",
   "homepage": "https://github.com/cchanxzy/react-currency-input-field",
   "scripts": {
-    "build": "rm -rf dist && tsc && NODE_ENV='prod' webpack --mode=production",
-    "start": "NODE_ENV='dev' webpack-dev-server --mode=development --hot",
+    "build": "rm -rf dist && tsc && NODE_ENV='production' webpack --config-name=prod --mode=production",
+    "start": "NODE_ENV='development' webpack-dev-server --config-name=dev --mode=development --hot",
     "test": "jest --coverage",
     "test:watch": "jest --coverage --watch",
     "lint": "tsc && eslint 'src/**/*.{js,ts,tsx}' --max-warnings=0",
-    "gh-predeploy": "NODE_ENV='dev' webpack --mode=development",
-    "gh-deploy": "yarn gh-predeploy && gh-pages -d dist",
+    "gh-predeploy": "NODE_ENV='production' webpack --config-name=dev --mode=production",
+    "gh-deploy": "yarn gh-predeploy && gh-pages -d demo/examples",
     "ci": "yarn && yarn build",
     "codecov": "codecov",
     "semantic-release": "semantic-release"

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -109,6 +109,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
 
     // Add padding or trim value to precision
     const newValue = padTrimValue(fixedDecimals, decimalSeparator, precision || fixedDecimalLength);
+    onChange && onChange(newValue, name);
     onBlurValue && onBlurValue(newValue, name);
 
     const formattedValue = formatValue({ value: newValue, ...formatValueOptions });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,50 +1,6 @@
-const webpack = require('webpack');
-const HtmlWebPackPlugin = require('html-webpack-plugin');
+/* eslint-disable @typescript-eslint/no-var-requires */
 
-const config = {
-  entry: './src/index.ts',
-  output: {
-    filename: 'index.js',
-    path: __dirname + '/dist',
-  },
-  devtool: 'source-map',
-  resolve: {
-    extensions: ['.ts', '.tsx', '.js', '.json'],
-  },
-  module: {
-    rules: [
-      { test: /\.tsx?$/, loader: 'awesome-typescript-loader' },
-      { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' },
-    ],
-  },
-  externals: {
-    react: 'React',
-    'react-dom': 'ReactDOM',
-  },
-  plugins: [
-    new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-    }),
-  ],
-};
+const prodConfig = require('./webpack/webpack-prod.config');
+const devConfig = require('./webpack/webpack-dev.config');
 
-if (process.env.NODE_ENV === 'prod') {
-  console.log('Building for production');
-  config.output.libraryTarget = 'commonjs2';
-  config.externals = {
-    react: 'commonjs react',
-  };
-}
-
-if (process.env.NODE_ENV === 'dev') {
-  console.log('Building for development');
-  config.entry = './src/example.tsx';
-
-  config.plugins.push(
-    new HtmlWebPackPlugin({
-      template: './src/example.html',
-    })
-  );
-}
-
-module.exports = config;
+module.exports = [prodConfig, devConfig];

--- a/webpack/webpack-base.config.js
+++ b/webpack/webpack-base.config.js
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const webpack = require('webpack');
+
+const config = {
+  entry: './src/index.ts',
+  output: {
+    filename: 'index.js',
+    path: __dirname + '/dist',
+  },
+  devtool: 'source-map',
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.json'],
+  },
+  module: {
+    rules: [
+      { test: /\.tsx?$/, loader: 'awesome-typescript-loader' },
+      { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' },
+    ],
+  },
+  externals: {
+    react: 'React',
+    'react-dom': 'ReactDOM',
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+    }),
+  ],
+};
+
+module.exports = config;

--- a/webpack/webpack-dev.config.js
+++ b/webpack/webpack-dev.config.js
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const webpack = require('webpack');
+const HtmlWebPackPlugin = require('html-webpack-plugin');
+const path = require('path');
+
+const baseConfig = require('./webpack-base.config');
+
+module.exports = {
+  ...baseConfig,
+  name: 'dev',
+  entry: './src/example.tsx',
+  output: {
+    filename: 'index.js',
+    path: path.join(__dirname, '../demo/examples'),
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+    }),
+    new HtmlWebPackPlugin({
+      template: './src/example.html',
+    }),
+  ],
+};

--- a/webpack/webpack-prod.config.js
+++ b/webpack/webpack-prod.config.js
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const baseConfig = require('./webpack-base.config');
+const path = require('path');
+
+module.exports = {
+  ...baseConfig,
+  name: 'prod',
+  output: {
+    filename: 'index.js',
+    path: path.join(__dirname, '../dist'),
+    libraryTarget: 'commonjs2',
+  },
+  externals: {
+    react: 'commonjs react',
+  },
+};


### PR DESCRIPTION
Splitting the webpack configs to production and dev so they are easier to manage.