### PR TITLE
Feat/change prop names

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Examples:
 - 2.5m = 2,500,000
 - 3.456B = 3,456,000,000
 
-This can be turned off by passing in `turnOffAbbreviations`.
+This can be turned off by passing in `disableAbbreviations`.
 
 ## Separators
 
@@ -130,7 +130,7 @@ Example if `fixedDecimalLength` was 2:
 | decimalSeparator       | `string`   | locale default | Separator between integer part and fractional part of value              |
 | groupSeparator         | `string`   | locale default | Separator between thousand, million and billion                          |
 | intlConfig             | `object`   |                | International locale config                                              |
-| turnOffAbbreviations   | `boolean`  | `false`        | Disable abbreviations eg. 1k > 1,000, 2m > 2,000,000                     |
+| disableAbbreviations   | `boolean`  | `false`        | Disable abbreviations eg. 1k > 1,000, 2m > 2,000,000                     |
 | disableGroupSeparators | `boolean`  | `false`        | Disable auto adding the group separator between values, eg. 1000 > 1,000 |
 
 ## Format values for display

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ import CurrencyInput from 'react-currency-input-field';
 
 Note: the separators cannot be a number, and `decimalSeparator` must be different to `groupSeparator`.
 
-To turn off auto adding the group separator, add `turnOffSeparators={true}`.
+To turn off auto adding the group separator, add `disableGroupSeparators={true}`.
 
 ## Intl Locale Config
 
@@ -109,29 +109,29 @@ Example if `fixedDecimalLength` was 2:
 
 ## Props
 
-| Name                 | Type       | Default        | Description                                                              |
-| -------------------- | ---------- | -------------- | ------------------------------------------------------------------------ |
-| allowDecimals        | `boolean`  | `true`         | Allow decimals                                                           |
-| allowNegativeValue   | `boolean`  | `true`         | Allow user to enter negative value                                       |
-| className            | `string`   |                | Class names                                                              |
-| decimalsLimit        | `number`   | `2`            | Limit length of decimals allowed                                         |
-| defaultValue         | `number`   |                | Default value                                                            |
-| value                | `number`   |                | Programmatically set the value                                           |
-| disabled             | `boolean`  | `false`        | Disabled                                                                 |
-| fixedDecimalLength   | `number`   |                | Value will always have the specified length of decimals                  |
-| id                   | `string`   |                | Component id                                                             |
-| maxLength            | `number`   |                | Maximum characters the user can enter                                    |
-| onChange             | `function` |                | Handle change in value                                                   |
-| onBlurValue          | `function` |                | Handle value onBlur                                                      |
-| placeholder          | `string`   |                | Placeholder if no value                                                  |
-| decimalScale         | `number`   |                | Specify decimal scale for padding/trimming                               |
-| prefix               | `string`   |                | Include a prefix eg. £ or \$                                             |
-| step                 | `number`   |                | Incremental value change on arrow down and arrow up key press            |
-| decimalSeparator     | `string`   | locale default | Separator between integer part and fractional part of value              |
-| groupSeparator       | `string`   | locale default | Separator between thousand, million and billion                          |
-| intlConfig           | `object`   |                | International locale config                                              |
-| turnOffAbbreviations | `boolean`  | `false`        | Disable abbreviations eg. 1k > 1,000, 2m > 2,000,000                     |
-| turnOffSeparators    | `boolean`  | `false`        | Disable auto adding the group separator between values, eg. 1000 > 1,000 |
+| Name                   | Type       | Default        | Description                                                              |
+| ---------------------- | ---------- | -------------- | ------------------------------------------------------------------------ |
+| allowDecimals          | `boolean`  | `true`         | Allow decimals                                                           |
+| allowNegativeValue     | `boolean`  | `true`         | Allow user to enter negative value                                       |
+| className              | `string`   |                | Class names                                                              |
+| decimalsLimit          | `number`   | `2`            | Limit length of decimals allowed                                         |
+| defaultValue           | `number`   |                | Default value                                                            |
+| value                  | `number`   |                | Programmatically set the value                                           |
+| disabled               | `boolean`  | `false`        | Disabled                                                                 |
+| fixedDecimalLength     | `number`   |                | Value will always have the specified length of decimals                  |
+| id                     | `string`   |                | Component id                                                             |
+| maxLength              | `number`   |                | Maximum characters the user can enter                                    |
+| onChange               | `function` |                | Handle change in value                                                   |
+| onBlurValue            | `function` |                | Handle value onBlur                                                      |
+| placeholder            | `string`   |                | Placeholder if no value                                                  |
+| decimalScale           | `number`   |                | Specify decimal scale for padding/trimming                               |
+| prefix                 | `string`   |                | Include a prefix eg. £ or \$                                             |
+| step                   | `number`   |                | Incremental value change on arrow down and arrow up key press            |
+| decimalSeparator       | `string`   | locale default | Separator between integer part and fractional part of value              |
+| groupSeparator         | `string`   | locale default | Separator between thousand, million and billion                          |
+| intlConfig             | `object`   |                | International locale config                                              |
+| turnOffAbbreviations   | `boolean`  | `false`        | Disable abbreviations eg. 1k > 1,000, 2m > 2,000,000                     |
+| disableGroupSeparators | `boolean`  | `false`        | Disable auto adding the group separator between values, eg. 1000 > 1,000 |
 
 ## Format values for display
 
@@ -144,7 +144,7 @@ const formattedValue = formatValue({
   value = 123456,
   groupSeparator = ',',
   decimalSeparator = '.',
-  turnOffSeparators = false,
+  disableGroupSeparators = false,
   prefix = '$',
 });
 ```

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Example if `fixedDecimalLength` was 2:
 | onChange             | `function` |                | Handle change in value                                                   |
 | onBlurValue          | `function` |                | Handle value onBlur                                                      |
 | placeholder          | `string`   |                | Placeholder if no value                                                  |
-| precision            | `number`   |                | Specify decimal precision for padding/trimming                           |
+| decimalScale         | `number`   |                | Specify decimal scale for padding/trimming                               |
 | prefix               | `string`   |                | Include a prefix eg. £ or \$                                             |
 | step                 | `number`   |                | Incremental value change on arrow down and arrow up key press            |
 | decimalSeparator     | `string`   | locale default | Separator between integer part and fractional part of value              |

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -34,7 +34,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       prefix,
       intlConfig,
       step,
-      turnOffSeparators = false,
+      disableGroupSeparators = false,
       turnOffAbbreviations = false,
       ...props
     }: CurrencyInputProps,
@@ -63,7 +63,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
     const formatValueOptions = {
       decimalSeparator,
       groupSeparator,
-      turnOffSeparators,
+      disableGroupSeparators,
       intlConfig,
       prefix,
     };

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -35,7 +35,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       intlConfig,
       step,
       disableGroupSeparators = false,
-      turnOffAbbreviations = false,
+      disableAbbreviations = false,
       ...props
     }: CurrencyInputProps,
     ref
@@ -74,7 +74,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       allowDecimals,
       decimalsLimit: decimalsLimit || fixedDecimalLength || 2,
       allowNegativeValue,
-      turnOffAbbreviations,
+      disableAbbreviations,
       prefix,
     };
 

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -30,7 +30,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       onBlurValue,
       fixedDecimalLength,
       placeholder,
-      precision,
+      decimalScale,
       prefix,
       intlConfig,
       step,
@@ -137,11 +137,11 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
 
       const fixedDecimals = fixedDecimalValue(valueOnly, decimalSeparator, fixedDecimalLength);
 
-      // Add padding or trim value to precision
+      // Add padding or trim value to decimalScale
       const newValue = padTrimValue(
         fixedDecimals,
         decimalSeparator,
-        precision || fixedDecimalLength
+        decimalScale || fixedDecimalLength
       );
       onChange && onChange(newValue, name);
       onBlurValue && onBlurValue(newValue, name);

--- a/src/components/CurrencyInputProps.ts
+++ b/src/components/CurrencyInputProps.ts
@@ -47,7 +47,14 @@ export type CurrencyInputProps = Overwrite<
     decimalsLimit?: number;
 
     /**
-     * Default value if not passing in value
+     * Specify decimal scale for padding/trimming
+     *
+     * Eg. 1 -> 1.99 or 1.234 -> 1.23
+     */
+    decimalScale?: number;
+
+    /**
+     * Default value if not passing in value via props
      */
     defaultValue?: number | string;
 
@@ -60,6 +67,8 @@ export type CurrencyInputProps = Overwrite<
 
     /**
      * Value will always have the specified length of decimals
+     *
+     * This formatting happens onBlur
      */
     fixedDecimalLength?: number;
 
@@ -75,14 +84,9 @@ export type CurrencyInputProps = Overwrite<
     onBlurValue?: (value: string | undefined, name?: string) => void;
 
     /**
-     * Placeholder
+     * Placeholder if there is no value
      */
     placeholder?: string;
-
-    /**
-     * Specify decimal precision for padding/trimming
-     */
-    precision?: number;
 
     /**
      * Include a prefix eg. £
@@ -95,16 +99,16 @@ export type CurrencyInputProps = Overwrite<
     step?: number;
 
     /**
-     * Separator between integer part and fractional part of value. Cannot be a number
+     * Separator between integer part and fractional part of value.
      *
-     * Default = "."
+     * This cannot be a number
      */
     decimalSeparator?: string;
 
     /**
-     * Separator between thousand, million and billion. Cannot be a number
+     * Separator between thousand, million and billion
      *
-     * Default = ","
+     * This cannot be a number
      */
     groupSeparator?: string;
 
@@ -127,7 +131,8 @@ export type CurrencyInputProps = Overwrite<
      *   { locale: 'ja-JP', currency: 'JPY' }
      *   { locale: 'en-IN', currency: 'INR' }
      *
-     * Any prefix, groupSeparator or decimalSeparator options passed in will override locale defaults
+     * Any prefix, groupSeparator or decimalSeparator options passed in
+     * will override Intl Locale config
      */
     intlConfig?: IntlConfig;
 

--- a/src/components/CurrencyInputProps.ts
+++ b/src/components/CurrencyInputProps.ts
@@ -68,7 +68,9 @@ export type CurrencyInputProps = Overwrite<
     /**
      * Value will always have the specified length of decimals
      *
-     * This formatting happens onBlur
+     * Eg. 123 -> 1.23
+     *
+     * Note: This formatting only happens onBlur
      */
     fixedDecimalLength?: number;
 
@@ -124,7 +126,7 @@ export type CurrencyInputProps = Overwrite<
      *
      * Default = false
      */
-    turnOffAbbreviations?: boolean;
+    disableAbbreviations?: boolean;
 
     /**
      * International locale config, examples:

--- a/src/components/CurrencyInputProps.ts
+++ b/src/components/CurrencyInputProps.ts
@@ -117,7 +117,7 @@ export type CurrencyInputProps = Overwrite<
      *
      * Default = false
      */
-    turnOffSeparators?: boolean;
+    disableGroupSeparators?: boolean;
 
     /**
      * Disable abbreviations eg. 1k > 1,000, 2m > 2,000,000

--- a/src/components/__tests__/CurrencyInput-abbreviated.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-abbreviated.spec.tsx
@@ -54,9 +54,9 @@ describe('<CurrencyInput /> component > abbreviated', () => {
     expect(view.update().find(`#${id}`).prop('value')).toBe('');
   });
 
-  describe('turnOffAbbreviations', () => {
-    it('should not allow abbreviations if turnOffAbbreviations is true', () => {
-      const view = shallow(<CurrencyInput id={id} onChange={onChangeSpy} turnOffAbbreviations />);
+  describe('disableAbbreviations', () => {
+    it('should not allow abbreviations if disableAbbreviations is true', () => {
+      const view = shallow(<CurrencyInput id={id} onChange={onChangeSpy} disableAbbreviations />);
       view.find(`#${id}`).simulate('change', { target: { value: '1k' } });
       expect(view.update().find(`#${id}`).prop('value')).toBe('1');
 

--- a/src/components/__tests__/CurrencyInput-fixedDecimalLength.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-fixedDecimalLength.spec.tsx
@@ -33,7 +33,7 @@ describe('<CurrencyInput /> component > fixedDecimalLength', () => {
       expect(updatedView.find(`#${id}`).prop('value')).toBe('$1.230');
     });
 
-    it('should work with precision and decimalSeparator', () => {
+    it('should work with decimalScale and decimalSeparator', () => {
       const view = shallow(
         <CurrencyInput
           id={id}
@@ -42,7 +42,7 @@ describe('<CurrencyInput /> component > fixedDecimalLength', () => {
           fixedDecimalLength={3}
           groupSeparator="."
           decimalSeparator=","
-          precision={2}
+          decimalScale={2}
           defaultValue={123}
         />
       );

--- a/src/components/__tests__/CurrencyInput-negative.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-negative.spec.tsx
@@ -13,7 +13,13 @@ describe('<CurrencyInput /> component > negative value', () => {
 
   it('should handle negative value input', () => {
     const view = shallow(
-      <CurrencyInput id={id} prefix="$" onChange={onChangeSpy} precision={2} defaultValue={123} />
+      <CurrencyInput
+        id={id}
+        prefix="$"
+        onChange={onChangeSpy}
+        decimalScale={2}
+        defaultValue={123}
+      />
     );
 
     const input = view.find(`#${id}`);
@@ -28,7 +34,13 @@ describe('<CurrencyInput /> component > negative value', () => {
 
   it('should call onChange with undefined and keep "-" sign as state value', () => {
     const view = shallow(
-      <CurrencyInput id={id} prefix="$" onChange={onChangeSpy} precision={2} defaultValue={123} />
+      <CurrencyInput
+        id={id}
+        prefix="$"
+        onChange={onChangeSpy}
+        decimalScale={2}
+        defaultValue={123}
+      />
     );
 
     const input = view.find(`#${id}`);
@@ -43,7 +55,13 @@ describe('<CurrencyInput /> component > negative value', () => {
 
   it('should not call onBlur if only negative sign and clears value', () => {
     const view = shallow(
-      <CurrencyInput id={id} prefix="$" onChange={onChangeSpy} precision={2} defaultValue={123} />
+      <CurrencyInput
+        id={id}
+        prefix="$"
+        onChange={onChangeSpy}
+        decimalScale={2}
+        defaultValue={123}
+      />
     );
 
     const input = view.find(`#${id}`);

--- a/src/components/__tests__/CurrencyInput-onBlurValue.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-onBlurValue.spec.tsx
@@ -21,7 +21,7 @@ describe('<CurrencyInput /> component > onBlurValue', () => {
         prefix="$"
         onBlurValue={onBlurValueSpy}
         onChange={onChangeSpy}
-        precision={2}
+        decimalScale={2}
       />
     );
     view.find(`#${id}`).simulate('blur', { target: { value: '123' } });

--- a/src/components/__tests__/CurrencyInput-precision.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-precision.spec.tsx
@@ -4,16 +4,16 @@ import CurrencyInput from '../CurrencyInput';
 
 const id = 'validationCustom01';
 
-describe('<CurrencyInput /> component > precision', () => {
+describe('<CurrencyInput /> component > decimalScale', () => {
   const onBlurValueSpy = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should pad to precision of 5 on blur', () => {
+  it('should pad to decimalScale of 5 on blur', () => {
     const view = shallow(
-      <CurrencyInput id={id} prefix="£" onBlurValue={onBlurValueSpy} precision={5} />
+      <CurrencyInput id={id} prefix="£" onBlurValue={onBlurValueSpy} decimalScale={5} />
     );
     view.find(`#${id}`).simulate('blur', { target: { value: '£1.5' } });
     expect(onBlurValueSpy).toBeCalledWith('1.50000', undefined);
@@ -22,9 +22,9 @@ describe('<CurrencyInput /> component > precision', () => {
     expect(updatedView.find(`#${id}`).prop('value')).toBe('£1.50000');
   });
 
-  it('should pad to precision of 2 on blur', () => {
+  it('should pad to decimalScale of 2 on blur', () => {
     const view = shallow(
-      <CurrencyInput id={id} prefix="£" onBlurValue={onBlurValueSpy} precision={2} />
+      <CurrencyInput id={id} prefix="£" onBlurValue={onBlurValueSpy} decimalScale={2} />
     );
     view.find(`#${id}`).simulate('blur', { target: { value: '£1' } });
     expect(onBlurValueSpy).toBeCalledWith('1.00', undefined);

--- a/src/components/__tests__/CurrencyInput-separators.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-separators.spec.tsx
@@ -18,7 +18,7 @@ describe('<CurrencyInput /> component > separators', () => {
         id={id}
         name={name}
         prefix="£"
-        turnOffSeparators={true}
+        disableGroupSeparators={true}
         onChange={onChangeSpy}
         defaultValue={10000}
       />

--- a/src/components/utils/__tests__/cleanValue.spec.ts
+++ b/src/components/utils/__tests__/cleanValue.spec.ts
@@ -163,21 +163,21 @@ describe('cleanValue', () => {
       expect(
         cleanValue({
           value: 'k',
-          turnOffAbbreviations: true,
+          disableAbbreviations: true,
         })
       ).toEqual('');
 
       expect(
         cleanValue({
           value: 'm',
-          turnOffAbbreviations: true,
+          disableAbbreviations: true,
         })
       ).toEqual('');
 
       expect(
         cleanValue({
           value: 'b',
-          turnOffAbbreviations: true,
+          disableAbbreviations: true,
         })
       ).toEqual('');
     });
@@ -187,7 +187,7 @@ describe('cleanValue', () => {
         cleanValue({
           value: '$k',
           prefix: '$',
-          turnOffAbbreviations: true,
+          disableAbbreviations: true,
         })
       ).toEqual('');
 
@@ -195,37 +195,37 @@ describe('cleanValue', () => {
         cleanValue({
           value: '£m',
           prefix: '£',
-          turnOffAbbreviations: true,
+          disableAbbreviations: true,
         })
       ).toEqual('');
     });
 
-    it('should ignore abbreviations if turnOffAbbreviations is true', () => {
+    it('should ignore abbreviations if disableAbbreviations is true', () => {
       expect(
         cleanValue({
           value: '1k',
-          turnOffAbbreviations: true,
+          disableAbbreviations: true,
         })
       ).toEqual('1');
 
       expect(
         cleanValue({
           value: '-2k',
-          turnOffAbbreviations: true,
+          disableAbbreviations: true,
         })
       ).toEqual('-2');
 
       expect(
         cleanValue({
           value: '25.6m',
-          turnOffAbbreviations: true,
+          disableAbbreviations: true,
         })
       ).toEqual('25.6');
 
       expect(
         cleanValue({
           value: '9b',
-          turnOffAbbreviations: true,
+          disableAbbreviations: true,
         })
       ).toEqual('9');
     });

--- a/src/components/utils/__tests__/formatValue.spec.ts
+++ b/src/components/utils/__tests__/formatValue.spec.ts
@@ -48,22 +48,22 @@ describe('formatValue', () => {
     ).toEqual('123456789');
   });
 
-  it('should NOT add separator if "turnOffSeparators" is true', () => {
+  it('should NOT add separator if "disableGroupSeparators" is true', () => {
     expect(
       formatValue({
         value: '1234567',
-        turnOffSeparators: true,
+        disableGroupSeparators: true,
       })
     ).toEqual('1234567');
   });
 
-  it('should NOT add separator if "turnOffSeparators" is true even if decimal and group separators specified', () => {
+  it('should NOT add separator if "disableGroupSeparators" is true even if decimal and group separators specified', () => {
     expect(
       formatValue({
         value: '1234567',
         decimalSeparator: '.',
         groupSeparator: ',',
-        turnOffSeparators: true,
+        disableGroupSeparators: true,
       })
     ).toEqual('1234567');
   });
@@ -216,14 +216,14 @@ describe('formatValue', () => {
       ).toEqual('¥654,321-00');
     });
 
-    it('should override locale if turnOffSeparators passed in', () => {
+    it('should override locale if disableGroupSeparators passed in', () => {
       expect(
         formatValue({
           value: '987654321',
           intlConfig: { locale: 'zh-CN', currency: 'CNY' },
           decimalSeparator: '.',
           groupSeparator: ',',
-          turnOffSeparators: true,
+          disableGroupSeparators: true,
         })
       ).toEqual('¥987654321');
     });

--- a/src/components/utils/__tests__/padTrimValue.spec.ts
+++ b/src/components/utils/__tests__/padTrimValue.spec.ts
@@ -1,7 +1,7 @@
 import { padTrimValue } from '../padTrimValue';
 
 describe('padTrimValue', () => {
-  it('should return original value if no precision', () => {
+  it('should return original value if no decimalScale', () => {
     const value = padTrimValue('1000000');
     expect(value).toEqual('1000000');
   });
@@ -21,12 +21,12 @@ describe('padTrimValue', () => {
     expect(value).toEqual('99.000');
   });
 
-  it('should pad with 0 if decimal length is less than precision', () => {
+  it('should pad with 0 if decimal length is less than decimalScale', () => {
     const value = padTrimValue('10.5', '.', 5);
     expect(value).toEqual('10.50000');
   });
 
-  it('should trim if decimal length is larger than precision', () => {
+  it('should trim if decimal length is larger than decimalScale', () => {
     const value = padTrimValue('10.599', '.', 2);
     expect(value).toEqual('10.59');
   });

--- a/src/components/utils/cleanValue.ts
+++ b/src/components/utils/cleanValue.ts
@@ -10,7 +10,7 @@ export type CleanValueOptions = {
   allowDecimals?: boolean;
   decimalsLimit?: number;
   allowNegativeValue?: boolean;
-  turnOffAbbreviations?: boolean;
+  disableAbbreviations?: boolean;
   prefix?: string;
 };
 
@@ -24,14 +24,14 @@ export const cleanValue = ({
   allowDecimals = true,
   decimalsLimit = 2,
   allowNegativeValue = true,
-  turnOffAbbreviations = false,
+  disableAbbreviations = false,
   prefix = '',
 }: CleanValueOptions): string => {
   if (value === '-') {
     return value;
   }
 
-  const abbreviations = turnOffAbbreviations ? [] : ['k', 'm', 'b'];
+  const abbreviations = disableAbbreviations ? [] : ['k', 'm', 'b'];
   const isNegative = new RegExp(`^\\d?-${prefix ? `${escapeRegExp(prefix)}?` : ''}\\d`).test(value);
 
   const [prefixWithValue, preValue] = RegExp(`(\\d+)-?${escapeRegExp(prefix)}`).exec(value) || [];
@@ -45,7 +45,7 @@ export const cleanValue = ({
 
   let valueOnly = withoutInvalidChars;
 
-  if (!turnOffAbbreviations) {
+  if (!disableAbbreviations) {
     // disallow letter without number
     if (abbreviations.some((letter) => letter === withoutInvalidChars.toLowerCase())) {
       return '';

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -28,7 +28,7 @@ type FormatValueOptions = {
    *
    * Default = false
    */
-  turnOffSeparators?: boolean;
+  disableGroupSeparators?: boolean;
 
   /**
    * Intl locale currency config
@@ -124,10 +124,10 @@ const replaceParts = (
     prefix,
     groupSeparator,
     decimalSeparator,
-    turnOffSeparators = false,
+    disableGroupSeparators = false,
   }: Pick<
     FormatValueOptions,
-    'prefix' | 'groupSeparator' | 'decimalSeparator' | 'turnOffSeparators'
+    'prefix' | 'groupSeparator' | 'decimalSeparator' | 'disableGroupSeparators'
   >
 ): string => {
   return parts
@@ -138,13 +138,13 @@ const replaceParts = (
         }
 
         if (type === 'group') {
-          return !turnOffSeparators
+          return !disableGroupSeparators
             ? [...prev, groupSeparator !== undefined ? groupSeparator : value]
             : prev;
         }
 
         if (type === 'decimal') {
-          return !turnOffSeparators
+          return !disableGroupSeparators
             ? [...prev, decimalSeparator !== undefined ? decimalSeparator : value]
             : prev;
         }

--- a/src/components/utils/padTrimValue.ts
+++ b/src/components/utils/padTrimValue.ts
@@ -1,5 +1,9 @@
-export const padTrimValue = (value: string, decimalSeparator = '.', precision?: number): string => {
-  if (!precision || value === '' || value === undefined) {
+export const padTrimValue = (
+  value: string,
+  decimalSeparator = '.',
+  decimalScale?: number
+): string => {
+  if (!decimalScale || value === '' || value === undefined) {
     return value;
   }
 
@@ -10,12 +14,12 @@ export const padTrimValue = (value: string, decimalSeparator = '.', precision?: 
   const [int, decimals] = value.split(decimalSeparator);
   let newValue = decimals || '';
 
-  if (newValue.length < precision) {
-    while (newValue.length < precision) {
+  if (newValue.length < decimalScale) {
+    while (newValue.length < decimalScale) {
       newValue += '0';
     }
   } else {
-    newValue = newValue.slice(0, precision);
+    newValue = newValue.slice(0, decimalScale);
   }
 
   return `${int}${decimalSeparator}${newValue}`;

--- a/src/examples/Example1.tsx
+++ b/src/examples/Example1.tsx
@@ -71,7 +71,7 @@ export const Example1: FC = () => {
                 onChange={validateValue}
                 onBlurValue={handleOnBlurValue}
                 prefix={prefix}
-                precision={2}
+                decimalScale={2}
                 step={1}
               />
               <div className="invalid-feedback">{errorMessage}</div>

--- a/src/examples/FormatValuesExample.tsx
+++ b/src/examples/FormatValuesExample.tsx
@@ -6,7 +6,7 @@ const FormatValuesExample: FC = () => {
   const [prefix, setPrefix] = useState('$');
   const [groupSeparator, setGroupSeparator] = useState(',');
   const [decimalSeparator, setDecimalSeparator] = useState('.');
-  const [turnOffSeparators, setTurnOffSeparators] = useState(false);
+  const [disableGroupSeparators, setdisableGroupSeparators] = useState(false);
 
   const handleValueChange = ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
     setValue(value);
@@ -31,7 +31,7 @@ const FormatValuesExample: FC = () => {
   const handleTurnOffSeparatorChange = ({
     target: { value },
   }: React.ChangeEvent<HTMLInputElement>) => {
-    setTurnOffSeparators(value === 'true' ? true : false);
+    setdisableGroupSeparators(value === 'true' ? true : false);
   };
 
   return (
@@ -88,26 +88,26 @@ const FormatValuesExample: FC = () => {
               <div className="ml-3 custom-control custom-radio custom-control-inline">
                 <input
                   type="radio"
-                  id="turnOffSeparatorsTrue"
+                  id="disableGroupSeparatorsTrue"
                   className="custom-control-input"
                   value="true"
                   onChange={handleTurnOffSeparatorChange}
-                  checked={turnOffSeparators}
+                  checked={disableGroupSeparators}
                 />
-                <label className="custom-control-label" htmlFor="turnOffSeparatorsTrue">
+                <label className="custom-control-label" htmlFor="disableGroupSeparatorsTrue">
                   True
                 </label>
               </div>
               <div className="custom-control custom-radio custom-control-inline">
                 <input
                   type="radio"
-                  id="turnOffSeparatorsFalse"
+                  id="disableGroupSeparatorsFalse"
                   className="custom-control-input"
                   value="false"
                   onChange={handleTurnOffSeparatorChange}
-                  checked={turnOffSeparators === false}
+                  checked={disableGroupSeparators === false}
                 />
-                <label className="custom-control-label" htmlFor="turnOffSeparatorsFalse">
+                <label className="custom-control-label" htmlFor="disableGroupSeparatorsFalse">
                   False
                 </label>
               </div>
@@ -120,7 +120,7 @@ const FormatValuesExample: FC = () => {
                 value,
                 groupSeparator,
                 decimalSeparator,
-                turnOffSeparators,
+                disableGroupSeparators,
                 prefix,
               })}
             </div>


### PR DESCRIPTION
Renaming some prop names so they are more accurate (or rather more intuitive)

Renamed:
- `precision` to `decimalScale`
- `turnOffSeparators` to `disableGroupSeparators`
- `turnOffAbbreviations` to `disableAbbreviations`