### PR TITLE
feat: renamed onChange prop to onValueChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import CurrencyInput from 'react-currency-input-field';
   defaultValue={1000}
   allowDecimals={true}
   decimalsLimit={2}
-  onChange={(value, name) => console.log(value, name)}
+  onValueChange={(value, name) => console.log(value, name)}
 />;
 ```
 
@@ -121,7 +121,7 @@ Example if `fixedDecimalLength` was 2:
 | fixedDecimalLength     | `number`   |                | Value will always have the specified length of decimals                  |
 | id                     | `string`   |                | Component id                                                             |
 | maxLength              | `number`   |                | Maximum characters the user can enter                                    |
-| onChange               | `function` |                | Handle change in value                                                   |
+| onValueChange          | `function` |                | Handle change in value                                                   |
 | onBlurValue            | `function` |                | Handle value onBlur                                                      |
 | placeholder            | `string`   |                | Placeholder if no value                                                  |
 | decimalScale           | `number`   |                | Specify decimal scale for padding/trimming                               |

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -26,7 +26,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       disabled = false,
       maxLength: userMaxLength,
       value: userValue,
-      onChange,
+      onValueChange,
       onBlurValue,
       fixedDecimalLength,
       placeholder,
@@ -36,6 +36,8 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       step,
       disableGroupSeparators = false,
       disableAbbreviations = false,
+      onChange,
+      onBlur,
       ...props
     }: CurrencyInputProps,
     ref
@@ -91,8 +93,8 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
     const processChange = (value: string, selectionStart?: number | null): void => {
       const valueOnly = cleanValue({ value, ...cleanValueOptions });
 
-      if (!valueOnly) {
-        onChange && onChange(undefined, name);
+      if (valueOnly === '') {
+        onValueChange && onValueChange(undefined, name);
         setStateValue('');
         return;
       }
@@ -102,7 +104,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       }
 
       if (valueOnly === '-') {
-        onChange && onChange(undefined, name);
+        onValueChange && onValueChange(undefined, name);
         setStateValue(value);
         return;
       }
@@ -117,16 +119,24 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
 
       setStateValue(formattedValue);
 
-      onChange && onChange(valueOnly, name);
+      onValueChange && onValueChange(valueOnly, name);
     };
 
-    const handleOnChange = ({
-      target: { value, selectionStart },
-    }: React.ChangeEvent<HTMLInputElement>): void => {
+    const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+      const {
+        target: { value, selectionStart },
+      } = event;
+
       processChange(value, selectionStart);
+
+      onChange && onChange(event);
     };
 
-    const handleOnBlur = ({ target: { value } }: React.ChangeEvent<HTMLInputElement>): void => {
+    const handleOnBlur = (event: React.FocusEvent<HTMLInputElement>): void => {
+      const {
+        target: { value },
+      } = event;
+
       const valueOnly = cleanValue({ value, ...cleanValueOptions });
 
       if (valueOnly === '-' || !valueOnly) {
@@ -143,14 +153,18 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
         decimalSeparator,
         decimalScale || fixedDecimalLength
       );
-      onChange && onChange(newValue, name);
+
+      onValueChange && onValueChange(newValue, name);
       onBlurValue && onBlurValue(newValue, name);
 
       const formattedValue = formatValue({
         ...formatValueOptions,
         value: newValue,
       });
+
       setStateValue(formattedValue);
+
+      onBlur && onBlur(event);
     };
 
     const handleOnKeyDown = ({ key }: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/CurrencyInputProps.ts
+++ b/src/components/CurrencyInputProps.ts
@@ -77,7 +77,7 @@ export type CurrencyInputProps = Overwrite<
     /**
      * Handle change in value
      */
-    onChange?: (value: string | undefined, name?: string) => void;
+    onValueChange?: (value: string | undefined, name?: string) => void;
 
     /**
      * Handle value onBlur

--- a/src/components/__tests__/CurrencyInput-abbreviated.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-abbreviated.spec.tsx
@@ -5,67 +5,69 @@ import CurrencyInput from '../CurrencyInput';
 const id = 'validationCustom01';
 
 describe('<CurrencyInput /> component > abbreviated', () => {
-  const onChangeSpy = jest.fn();
+  const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('should allow abbreviated values with k', () => {
-    const view = shallow(<CurrencyInput id={id} prefix="£" onChange={onChangeSpy} />);
+    const view = shallow(<CurrencyInput id={id} prefix="£" onValueChange={onValueChangeSpy} />);
     view.find(`#${id}`).simulate('change', { target: { value: '£1.5k' } });
-    expect(onChangeSpy).toBeCalledWith('1500', undefined);
+    expect(onValueChangeSpy).toBeCalledWith('1500', undefined);
 
     expect(view.update().find(`#${id}`).prop('value')).toBe('£1,500');
   });
 
   it('should allow abbreviated values with m', () => {
-    const view = shallow(<CurrencyInput id={id} prefix="£" onChange={onChangeSpy} />);
+    const view = shallow(<CurrencyInput id={id} prefix="£" onValueChange={onValueChangeSpy} />);
     view.find(`#${id}`).simulate('change', { target: { value: '£2.123M' } });
-    expect(onChangeSpy).toBeCalledWith('2123000', undefined);
+    expect(onValueChangeSpy).toBeCalledWith('2123000', undefined);
 
     expect(view.update().find(`#${id}`).prop('value')).toBe('£2,123,000');
   });
 
   it('should allow abbreviated values with b', () => {
-    const view = shallow(<CurrencyInput id={id} prefix="£" onChange={onChangeSpy} />);
+    const view = shallow(<CurrencyInput id={id} prefix="£" onValueChange={onValueChangeSpy} />);
     view.find(`#${id}`).simulate('change', { target: { value: '£1.599B' } });
-    expect(onChangeSpy).toBeCalledWith('1599000000', undefined);
+    expect(onValueChangeSpy).toBeCalledWith('1599000000', undefined);
 
     expect(view.update().find(`#${id}`).prop('value')).toBe('£1,599,000,000');
   });
 
   it('should not abbreviate any other letters', () => {
-    const view = shallow(<CurrencyInput id={id} prefix="£" onChange={onChangeSpy} />);
+    const view = shallow(<CurrencyInput id={id} prefix="£" onValueChange={onValueChangeSpy} />);
     view.find(`#${id}`).simulate('change', { target: { value: '£1.5e' } });
-    expect(onChangeSpy).toBeCalledWith('1.5', undefined);
+    expect(onValueChangeSpy).toBeCalledWith('1.5', undefined);
 
     expect(view.update().find(`#${id}`).prop('value')).toBe('£1.5');
   });
 
   it('should not allow abbreviation without number', () => {
-    const view = shallow(<CurrencyInput id={id} onChange={onChangeSpy} />);
+    const view = shallow(<CurrencyInput id={id} onValueChange={onValueChangeSpy} />);
     view.find(`#${id}`).simulate('change', { target: { value: 'k' } });
-    expect(onChangeSpy).toBeCalledWith(undefined, undefined);
+    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
     expect(view.update().find(`#${id}`).prop('value')).toBe('');
 
     view.find(`#${id}`).simulate('change', { target: { value: 'M' } });
-    expect(onChangeSpy).toBeCalledWith(undefined, undefined);
+    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
     expect(view.update().find(`#${id}`).prop('value')).toBe('');
   });
 
   describe('disableAbbreviations', () => {
     it('should not allow abbreviations if disableAbbreviations is true', () => {
-      const view = shallow(<CurrencyInput id={id} onChange={onChangeSpy} disableAbbreviations />);
+      const view = shallow(
+        <CurrencyInput id={id} onValueChange={onValueChangeSpy} disableAbbreviations />
+      );
       view.find(`#${id}`).simulate('change', { target: { value: '1k' } });
       expect(view.update().find(`#${id}`).prop('value')).toBe('1');
 
       view.find(`#${id}`).simulate('change', { target: { value: '23m' } });
-      expect(onChangeSpy).toBeCalledWith('23', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('23', undefined);
       expect(view.update().find(`#${id}`).prop('value')).toBe('23');
 
       view.find(`#${id}`).simulate('change', { target: { value: '55b' } });
-      expect(onChangeSpy).toBeCalledWith('55', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('55', undefined);
       expect(view.update().find(`#${id}`).prop('value')).toBe('55');
     });
   });

--- a/src/components/__tests__/CurrencyInput-decimals.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-decimals.spec.tsx
@@ -5,7 +5,7 @@ import CurrencyInput from '../CurrencyInput';
 const id = 'validationCustom01';
 
 describe('<CurrencyInput /> component > decimals', () => {
-  const onChangeSpy = jest.fn();
+  const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -13,10 +13,10 @@ describe('<CurrencyInput /> component > decimals', () => {
 
   it('should allow value with decimals if allowDecimals is true', () => {
     const view = shallow(
-      <CurrencyInput allowDecimals={true} id={id} prefix="£" onChange={onChangeSpy} />
+      <CurrencyInput allowDecimals={true} id={id} prefix="£" onValueChange={onValueChangeSpy} />
     );
     view.find(`#${id}`).simulate('change', { target: { value: '£1,234.56' } });
-    expect(onChangeSpy).toBeCalledWith('1234.56', undefined);
+    expect(onValueChangeSpy).toBeCalledWith('1234.56', undefined);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('£1,234.56');
@@ -24,10 +24,10 @@ describe('<CurrencyInput /> component > decimals', () => {
 
   it('should disallow value with decimals if allowDecimals is false', () => {
     const view = shallow(
-      <CurrencyInput allowDecimals={false} id={id} prefix="£" onChange={onChangeSpy} />
+      <CurrencyInput allowDecimals={false} id={id} prefix="£" onValueChange={onValueChangeSpy} />
     );
     view.find(`#${id}`).simulate('change', { target: { value: '£1,234.56' } });
-    expect(onChangeSpy).toBeCalledWith('1234', undefined);
+    expect(onValueChangeSpy).toBeCalledWith('1234', undefined);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('£1,234');
@@ -35,10 +35,10 @@ describe('<CurrencyInput /> component > decimals', () => {
 
   it('should limit decimals to decimalsLimit length', () => {
     const view = shallow(
-      <CurrencyInput id={id} decimalsLimit={3} prefix="£" onChange={onChangeSpy} />
+      <CurrencyInput id={id} decimalsLimit={3} prefix="£" onValueChange={onValueChangeSpy} />
     );
     view.find(`#${id}`).simulate('change', { target: { value: '£1,234.56789' } });
-    expect(onChangeSpy).toBeCalledWith('1234.567', undefined);
+    expect(onValueChangeSpy).toBeCalledWith('1234.567', undefined);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('£1,234.567');
@@ -46,7 +46,7 @@ describe('<CurrencyInput /> component > decimals', () => {
 
   it('should be disabled if disabled prop is true', () => {
     const view = shallow(
-      <CurrencyInput id={id} decimalsLimit={3} disabled={true} onChange={onChangeSpy} />
+      <CurrencyInput id={id} decimalsLimit={3} disabled={true} onValueChange={onValueChangeSpy} />
     );
     expect(view.find(`#${id}`).prop('disabled')).toBe(true);
   });

--- a/src/components/__tests__/CurrencyInput-handleKeyDown.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-handleKeyDown.spec.tsx
@@ -5,7 +5,7 @@ import CurrencyInput from '../CurrencyInput';
 const id = 'validationCustom01';
 
 describe('<CurrencyInput /> component > handleKeyDown', () => {
-  const onChangeSpy = jest.fn();
+  const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -13,48 +13,58 @@ describe('<CurrencyInput /> component > handleKeyDown', () => {
 
   it('should not change value if no step prop', () => {
     const view = shallow(
-      <CurrencyInput id={id} prefix="£" defaultValue={100} onChange={onChangeSpy} />
+      <CurrencyInput id={id} prefix="£" defaultValue={100} onValueChange={onValueChangeSpy} />
     );
 
     // Arrow up
     view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
-    expect(onChangeSpy).not.toBeCalled();
+    expect(onValueChangeSpy).not.toBeCalled();
     expect(view.update().find(`#${id}`).prop('value')).toBe('£100');
 
     // Arrow down
     view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
-    expect(onChangeSpy).not.toBeCalled();
+    expect(onValueChangeSpy).not.toBeCalled();
     expect(view.update().find(`#${id}`).prop('value')).toBe('£100');
   });
 
   it('should handle negative step', () => {
     const view = shallow(
-      <CurrencyInput id={id} prefix="£" defaultValue={100} step={-2} onChange={onChangeSpy} />
+      <CurrencyInput
+        id={id}
+        prefix="£"
+        defaultValue={100}
+        step={-2}
+        onValueChange={onValueChangeSpy}
+      />
     );
 
     view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
-    expect(onChangeSpy).toHaveBeenCalledWith('98', undefined);
+    expect(onValueChangeSpy).toHaveBeenCalledWith('98', undefined);
     expect(view.update().find(`#${id}`).prop('value')).toBe('£98');
 
     view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
-    expect(onChangeSpy).toHaveBeenCalledWith('100', undefined);
+    expect(onValueChangeSpy).toHaveBeenCalledWith('100', undefined);
     expect(view.update().find(`#${id}`).prop('value')).toBe('£100');
   });
 
   describe('without value ie. default 0', () => {
     it('should handle arrow down key', () => {
-      const view = shallow(<CurrencyInput id={id} prefix="£" step={1} onChange={onChangeSpy} />);
+      const view = shallow(
+        <CurrencyInput id={id} prefix="£" step={1} onValueChange={onValueChangeSpy} />
+      );
 
       view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
-      expect(onChangeSpy).toBeCalledWith('-1', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('-1', undefined);
       expect(view.update().find(`#${id}`).prop('value')).toBe('-£1');
     });
 
     it('should handle arrow down key', () => {
-      const view = shallow(<CurrencyInput id={id} prefix="£" step={1} onChange={onChangeSpy} />);
+      const view = shallow(
+        <CurrencyInput id={id} prefix="£" step={1} onValueChange={onValueChangeSpy} />
+      );
 
       view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
-      expect(onChangeSpy).toBeCalledWith('1', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('1', undefined);
       expect(view.update().find(`#${id}`).prop('value')).toBe('£1');
     });
   });
@@ -62,49 +72,61 @@ describe('<CurrencyInput /> component > handleKeyDown', () => {
   describe('with value 99 and step 1.25', () => {
     it('should handle arrow down key', () => {
       const view = shallow(
-        <CurrencyInput id={id} prefix="£" value={99} step={1.25} onChange={onChangeSpy} />
+        <CurrencyInput id={id} prefix="£" value={99} step={1.25} onValueChange={onValueChangeSpy} />
       );
 
       view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
-      expect(onChangeSpy).toHaveBeenCalledWith('97.75', undefined);
+      expect(onValueChangeSpy).toHaveBeenCalledWith('97.75', undefined);
     });
 
     it('should handle arrow up key', () => {
       const view = shallow(
-        <CurrencyInput id={id} prefix="£" value={99} step={1.25} onChange={onChangeSpy} />
+        <CurrencyInput id={id} prefix="£" value={99} step={1.25} onValueChange={onValueChangeSpy} />
       );
 
       view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
-      expect(onChangeSpy).toHaveBeenCalledWith('100.25', undefined);
+      expect(onValueChangeSpy).toHaveBeenCalledWith('100.25', undefined);
     });
   });
 
   describe('with defaultValue 100 and step 5.5', () => {
     it('should handle arrow down key', () => {
       const view = shallow(
-        <CurrencyInput id={id} prefix="£" defaultValue={100} step={5.5} onChange={onChangeSpy} />
+        <CurrencyInput
+          id={id}
+          prefix="£"
+          defaultValue={100}
+          step={5.5}
+          onValueChange={onValueChangeSpy}
+        />
       );
 
       view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
-      expect(onChangeSpy).toBeCalledWith('94.5', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('94.5', undefined);
       expect(view.update().find(`#${id}`).prop('value')).toBe('£94.5');
 
       view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
-      expect(onChangeSpy).toBeCalledWith('89', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('89', undefined);
       expect(view.update().find(`#${id}`).prop('value')).toBe('£89');
     });
 
     it('should handle arrow up key', () => {
       const view = shallow(
-        <CurrencyInput id={id} prefix="£" defaultValue={100} step={5.5} onChange={onChangeSpy} />
+        <CurrencyInput
+          id={id}
+          prefix="£"
+          defaultValue={100}
+          step={5.5}
+          onValueChange={onValueChangeSpy}
+        />
       );
 
       view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
-      expect(onChangeSpy).toBeCalledWith('105.5', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('105.5', undefined);
       expect(view.update().find(`#${id}`).prop('value')).toBe('£105.5');
 
       view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
-      expect(onChangeSpy).toBeCalledWith('111', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('111', undefined);
       expect(view.update().find(`#${id}`).prop('value')).toBe('£111');
     });
   });
@@ -118,16 +140,16 @@ describe('<CurrencyInput /> component > handleKeyDown', () => {
           defaultValue={-99}
           step={1}
           maxLength={2}
-          onChange={onChangeSpy}
+          onValueChange={onValueChangeSpy}
         />
       );
 
       view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
-      expect(onChangeSpy).not.toBeCalled();
+      expect(onValueChangeSpy).not.toBeCalled();
       expect(view.update().find(`#${id}`).prop('value')).toBe('-£99');
 
       view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
-      expect(onChangeSpy).toHaveBeenCalledWith('-98', undefined);
+      expect(onValueChangeSpy).toHaveBeenCalledWith('-98', undefined);
       expect(view.update().find(`#${id}`).prop('value')).toBe('-£98');
     });
 
@@ -139,16 +161,16 @@ describe('<CurrencyInput /> component > handleKeyDown', () => {
           defaultValue={99}
           step={1}
           maxLength={2}
-          onChange={onChangeSpy}
+          onValueChange={onValueChangeSpy}
         />
       );
 
       view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
-      expect(onChangeSpy).not.toBeCalled();
+      expect(onValueChangeSpy).not.toBeCalled();
       expect(view.update().find(`#${id}`).prop('value')).toBe('£99');
 
       view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
-      expect(onChangeSpy).toHaveBeenCalledWith('98', undefined);
+      expect(onValueChangeSpy).toHaveBeenCalledWith('98', undefined);
       expect(view.update().find(`#${id}`).prop('value')).toBe('£98');
     });
   });

--- a/src/components/__tests__/CurrencyInput-intl-config.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-intl-config.spec.tsx
@@ -62,25 +62,25 @@ describe('<CurrencyInput /> component > intlConfig', () => {
     expect(view.find(`#${id}`).prop('value')).toBe('$123,456-789');
   });
 
-  describe('onChange', () => {
-    const onChangeSpy = jest.fn();
+  describe('onValueChange', () => {
+    const onValueChangeSpy = jest.fn();
 
     beforeEach(() => {
       jest.clearAllMocks();
     });
 
-    it('should handle onChange with intl config settings (en-IN, INR)', () => {
+    it('should handle onValueChange with intl config settings (en-IN, INR)', () => {
       const view = shallow(
         <CurrencyInput
           id={id}
           intlConfig={{ locale: 'en-IN', currency: 'INR' }}
-          onChange={onChangeSpy}
+          onValueChange={onValueChangeSpy}
         />
       );
       expect(view.find(`#${id}`).prop('value')).toBe('');
 
       view.find(`#${id}`).simulate('change', { target: { value: '₹12,34,567' } });
-      expect(onChangeSpy).toBeCalledWith('1234567', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('1234567', undefined);
 
       const updatedView = view.update();
       expect(updatedView.find(`#${id}`).prop('value')).toBe('₹12,34,567');

--- a/src/components/__tests__/CurrencyInput-maxLength.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-maxLength.spec.tsx
@@ -5,7 +5,7 @@ import CurrencyInput from '../CurrencyInput';
 const id = 'validationCustom01';
 
 describe('<CurrencyInput /> component > maxLength', () => {
-  const onChangeSpy = jest.fn();
+  const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -17,7 +17,7 @@ describe('<CurrencyInput /> component > maxLength', () => {
         id={id}
         name={name}
         prefix="£"
-        onChange={onChangeSpy}
+        onValueChange={onValueChangeSpy}
         maxLength={3}
         defaultValue={123}
       />
@@ -27,7 +27,7 @@ describe('<CurrencyInput /> component > maxLength', () => {
     expect(input.prop('value')).toBe('£123');
 
     input.simulate('change', { target: { value: '£1234' } });
-    expect(onChangeSpy).not.toBeCalled();
+    expect(onValueChangeSpy).not.toBeCalled();
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('£123');
@@ -39,7 +39,7 @@ describe('<CurrencyInput /> component > maxLength', () => {
         id={id}
         name={name}
         prefix="£"
-        onChange={onChangeSpy}
+        onValueChange={onValueChangeSpy}
         maxLength={3}
         defaultValue={-123}
       />
@@ -49,11 +49,11 @@ describe('<CurrencyInput /> component > maxLength', () => {
     expect(input.prop('value')).toBe('-£123');
 
     input.simulate('change', { target: { value: '-£1234' } });
-    expect(onChangeSpy).not.toBeCalled();
+    expect(onValueChangeSpy).not.toBeCalled();
     expect(view.update().find(`#${id}`).prop('value')).toBe('-£123');
 
     input.simulate('change', { target: { value: '-£125' } });
-    expect(onChangeSpy).toHaveBeenCalledWith('-125', '');
+    expect(onValueChangeSpy).toHaveBeenCalledWith('-125', '');
     expect(view.update().find(`#${id}`).prop('value')).toBe('-£125');
   });
 });

--- a/src/components/__tests__/CurrencyInput-negative.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-negative.spec.tsx
@@ -5,7 +5,7 @@ import CurrencyInput from '../CurrencyInput';
 const id = 'validationCustom01';
 
 describe('<CurrencyInput /> component > negative value', () => {
-  const onChangeSpy = jest.fn();
+  const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -16,7 +16,7 @@ describe('<CurrencyInput /> component > negative value', () => {
       <CurrencyInput
         id={id}
         prefix="$"
-        onChange={onChangeSpy}
+        onValueChange={onValueChangeSpy}
         decimalScale={2}
         defaultValue={123}
       />
@@ -26,18 +26,18 @@ describe('<CurrencyInput /> component > negative value', () => {
     expect(input.prop('value')).toBe('$123');
 
     input.simulate('change', { target: { value: '-$1234' } });
-    expect(onChangeSpy).toBeCalledWith('-1234', undefined);
+    expect(onValueChangeSpy).toBeCalledWith('-1234', undefined);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('-$1,234');
   });
 
-  it('should call onChange with undefined and keep "-" sign as state value', () => {
+  it('should call onValueChange with undefined and keep "-" sign as state value', () => {
     const view = shallow(
       <CurrencyInput
         id={id}
         prefix="$"
-        onChange={onChangeSpy}
+        onValueChange={onValueChangeSpy}
         decimalScale={2}
         defaultValue={123}
       />
@@ -47,7 +47,7 @@ describe('<CurrencyInput /> component > negative value', () => {
     expect(input.prop('value')).toBe('$123');
 
     input.simulate('change', { target: { value: '-' } });
-    expect(onChangeSpy).toBeCalledWith(undefined, undefined);
+    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('-');
@@ -58,7 +58,7 @@ describe('<CurrencyInput /> component > negative value', () => {
       <CurrencyInput
         id={id}
         prefix="$"
-        onChange={onChangeSpy}
+        onValueChange={onValueChangeSpy}
         decimalScale={2}
         defaultValue={123}
       />
@@ -68,7 +68,7 @@ describe('<CurrencyInput /> component > negative value', () => {
     expect(input.prop('value')).toBe('$123');
 
     input.simulate('blur', { target: { value: '-' } });
-    expect(onChangeSpy).not.toBeCalled();
+    expect(onValueChangeSpy).not.toBeCalled();
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('');
@@ -79,7 +79,7 @@ describe('<CurrencyInput /> component > negative value', () => {
       <CurrencyInput
         id={id}
         prefix="$"
-        onChange={onChangeSpy}
+        onValueChange={onValueChangeSpy}
         allowNegativeValue={false}
         defaultValue={123}
       />
@@ -89,7 +89,7 @@ describe('<CurrencyInput /> component > negative value', () => {
     expect(input.prop('value')).toBe('$123');
 
     input.simulate('change', { target: { value: '-$1234' } });
-    expect(onChangeSpy).toBeCalledWith('1234', undefined);
+    expect(onValueChangeSpy).toBeCalledWith('1234', undefined);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('$1,234');

--- a/src/components/__tests__/CurrencyInput-onBlurValue.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-onBlurValue.spec.tsx
@@ -7,26 +7,26 @@ const name = 'inputName';
 
 describe('<CurrencyInput /> component > onBlurValue', () => {
   const onBlurValueSpy = jest.fn();
-  const onChangeSpy = jest.fn();
+  const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should call onBlurValue and onChange', () => {
+  it('should call onBlurValue and onValueChange', () => {
     const view = shallow(
       <CurrencyInput
         id={id}
         name={name}
         prefix="$"
         onBlurValue={onBlurValueSpy}
-        onChange={onChangeSpy}
+        onValueChange={onValueChangeSpy}
         decimalScale={2}
       />
     );
     view.find(`#${id}`).simulate('blur', { target: { value: '123' } });
     expect(onBlurValueSpy).toBeCalledWith('123.00', name);
-    expect(onChangeSpy).toBeCalledWith('123.00', name);
+    expect(onValueChangeSpy).toBeCalledWith('123.00', name);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('$123.00');
@@ -93,5 +93,23 @@ describe('<CurrencyInput /> component > onBlurValue', () => {
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('$123');
+  });
+
+  it('should not let onBlur override onBlurValue prop', () => {
+    const onBlurSpy = jest.fn();
+    const view = shallow(
+      <CurrencyInput
+        id={id}
+        name={name}
+        prefix="$"
+        onBlur={onBlurSpy}
+        onBlurValue={onBlurValueSpy}
+      />
+    );
+    const event = { target: { value: '$123hello' } };
+
+    view.find(`#${id}`).simulate('blur', event);
+    expect(onBlurSpy).toBeCalledWith(event);
+    expect(onBlurValueSpy).toBeCalledWith('123', name);
   });
 });

--- a/src/components/__tests__/CurrencyInput-separators.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-separators.spec.tsx
@@ -6,7 +6,7 @@ const id = 'validationCustom01';
 const name = 'inputName';
 
 describe('<CurrencyInput /> component > separators', () => {
-  const onChangeSpy = jest.fn();
+  const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -19,7 +19,7 @@ describe('<CurrencyInput /> component > separators', () => {
         name={name}
         prefix="£"
         disableGroupSeparators={true}
-        onChange={onChangeSpy}
+        onValueChange={onValueChangeSpy}
         defaultValue={10000}
       />
     );
@@ -28,7 +28,7 @@ describe('<CurrencyInput /> component > separators', () => {
     expect(input.prop('value')).toBe('£10000');
 
     input.simulate('change', { target: { value: '£123456' } });
-    expect(onChangeSpy).toBeCalledWith('123456', name);
+    expect(onValueChangeSpy).toBeCalledWith('123456', name);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('£123456');
@@ -42,11 +42,11 @@ describe('<CurrencyInput /> component > separators', () => {
         prefix="£"
         decimalSeparator=","
         groupSeparator="."
-        onChange={onChangeSpy}
+        onValueChange={onValueChangeSpy}
       />
     );
     view.find(`#${id}`).simulate('change', { target: { value: '£123.456,33' } });
-    expect(onChangeSpy).toBeCalledWith('123456,33', name);
+    expect(onValueChangeSpy).toBeCalledWith('123456,33', name);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('£123.456,33');
@@ -77,7 +77,7 @@ describe('<CurrencyInput /> component > separators', () => {
           prefix="£"
           decimalSeparator="."
           groupSeparator={'2'}
-          onChange={onChangeSpy}
+          onValueChange={onValueChangeSpy}
           defaultValue={10000}
         />
       )

--- a/src/components/__tests__/CurrencyInput.spec.tsx
+++ b/src/components/__tests__/CurrencyInput.spec.tsx
@@ -8,7 +8,7 @@ const placeholder = '£1,000';
 const name = 'inputName';
 
 describe('<CurrencyInput /> component', () => {
-  const onChangeSpy = jest.fn();
+  const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -78,58 +78,84 @@ describe('<CurrencyInput /> component', () => {
   });
 
   it('should allow value change with number', () => {
-    const view = shallow(<CurrencyInput id={id} prefix="£" onChange={onChangeSpy} />);
+    const view = shallow(<CurrencyInput id={id} prefix="£" onValueChange={onValueChangeSpy} />);
     view.find(`#${id}`).simulate('change', { target: { value: '100' } });
 
-    expect(onChangeSpy).toBeCalledWith('100', undefined);
+    expect(onValueChangeSpy).toBeCalledWith('100', undefined);
   });
 
   it('should prefix 0 value', () => {
     const view = shallow(
-      <CurrencyInput id={id} name={name} prefix="£" value={0} onChange={onChangeSpy} />
+      <CurrencyInput id={id} name={name} prefix="£" value={0} onValueChange={onValueChangeSpy} />
     );
     expect(view.find(`#${id}`).prop('value')).toBe('£0');
   });
 
   it('should allow 0 value on change', () => {
-    const view = shallow(<CurrencyInput id={id} name={name} prefix="£" onChange={onChangeSpy} />);
+    const view = shallow(
+      <CurrencyInput id={id} name={name} prefix="£" onValueChange={onValueChangeSpy} />
+    );
     view.find(`#${id}`).simulate('change', { target: { value: '0' } });
-    expect(onChangeSpy).toBeCalledWith('0', name);
+    expect(onValueChangeSpy).toBeCalledWith('0', name);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('£0');
   });
 
   it('should allow empty value', () => {
-    const view = shallow(<CurrencyInput id={id} name={name} prefix="£" onChange={onChangeSpy} />);
+    const view = shallow(
+      <CurrencyInput id={id} name={name} prefix="£" onValueChange={onValueChangeSpy} />
+    );
     view.find(`#${id}`).simulate('change', { target: { value: '' } });
-    expect(onChangeSpy).toBeCalledWith(undefined, name);
+    expect(onValueChangeSpy).toBeCalledWith(undefined, name);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('');
   });
 
   it('should callback name as second parameter if name prop provided', () => {
-    const view = shallow(<CurrencyInput id={id} name={name} prefix="£" onChange={onChangeSpy} />);
+    const view = shallow(
+      <CurrencyInput id={id} name={name} prefix="£" onValueChange={onValueChangeSpy} />
+    );
     view.find(`#${id}`).simulate('change', { target: { value: '£123' } });
-    expect(onChangeSpy).toBeCalledWith('123', name);
+    expect(onValueChangeSpy).toBeCalledWith('123', name);
   });
 
   it('should not allow invalid characters', () => {
-    const view = shallow(<CurrencyInput id={id} name={name} prefix="£" onChange={onChangeSpy} />);
+    const view = shallow(
+      <CurrencyInput id={id} name={name} prefix="£" onValueChange={onValueChangeSpy} />
+    );
     view.find(`#${id}`).simulate('change', { target: { value: 'hello' } });
-    expect(onChangeSpy).toBeCalledWith(undefined, name);
+    expect(onValueChangeSpy).toBeCalledWith(undefined, name);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('');
   });
 
   it('should ignore invalid characters', () => {
-    const view = shallow(<CurrencyInput id={id} name={name} prefix="£" onChange={onChangeSpy} />);
+    const view = shallow(
+      <CurrencyInput id={id} name={name} prefix="£" onValueChange={onValueChangeSpy} />
+    );
     view.find(`#${id}`).simulate('change', { target: { value: '£123hello' } });
-    expect(onChangeSpy).toBeCalledWith('123', name);
+    expect(onValueChangeSpy).toBeCalledWith('123', name);
 
     const updatedView = view.update();
     expect(updatedView.find(`#${id}`).prop('value')).toBe('£123');
+  });
+
+  it('should call onChange with raw event', () => {
+    const onChangeSpy = jest.fn();
+    const view = shallow(<CurrencyInput id={id} prefix="£" onChange={onChangeSpy} />);
+    const event = { target: { value: '£123' } };
+    view.find(`#${id}`).simulate('change', event);
+    expect(onChangeSpy).toBeCalledWith(event);
+  });
+
+  it('should call onBlur with raw event', () => {
+    const onBlurSpy = jest.fn();
+    const view = shallow(<CurrencyInput id={id} prefix="£" onBlur={onBlurSpy} />);
+    const event = { target: { value: '£123' } };
+    view.find(`#${id}`).simulate('blur', event);
+    expect(onBlurSpy).toBeCalledWith(event);
   });
 });

--- a/src/examples/Example1.tsx
+++ b/src/examples/Example1.tsx
@@ -68,7 +68,7 @@ export const Example1: FC = () => {
                 name="input-1"
                 className={`form-control ${className}`}
                 value={value}
-                onChange={validateValue}
+                onValueChange={validateValue}
                 onBlurValue={handleOnBlurValue}
                 prefix={prefix}
                 decimalScale={2}
@@ -80,7 +80,7 @@ export const Example1: FC = () => {
               <pre className="h-100 p-3 bg-dark text-white">
                 <div className="row">
                   <div className="col-6">
-                    <div className="text-muted mr-3">onChange:</div>
+                    <div className="text-muted mr-3">onValueChange:</div>
                     {rawValue}
                   </div>
                   <div className="col-6">

--- a/src/examples/Example2.tsx
+++ b/src/examples/Example2.tsx
@@ -48,7 +48,7 @@ export const Example2: FC = () => {
                 placeholder="$1,234,567"
                 allowDecimals={false}
                 className={`form-control ${className}`}
-                onChange={validateValue}
+                onValueChange={validateValue}
                 onBlurValue={handleOnBlurValue}
                 prefix={'$'}
                 step={10}
@@ -59,7 +59,7 @@ export const Example2: FC = () => {
               <pre className="h-100 p-3 bg-dark text-white">
                 <div className="row">
                   <div className="col-6">
-                    <div className="text-muted mr-3">onChange:</div>
+                    <div className="text-muted mr-3">onValueChange:</div>
                     {rawValue}
                   </div>
                   <div className="col-6">

--- a/src/examples/Example3.tsx
+++ b/src/examples/Example3.tsx
@@ -41,7 +41,7 @@ export const Example3: FC = () => {
   const prefix = '£';
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  const handleOnChange = (_value: string | undefined, fieldName: string | undefined): void => {
+  const handleonValueChange = (_value: string | undefined, fieldName: string | undefined): void => {
     if (!fieldName) {
       return;
     }
@@ -102,7 +102,7 @@ export const Example3: FC = () => {
                 name="field1"
                 className={`form-control ${state.field1.validationClass}`}
                 value={state.field1.value}
-                onChange={handleOnChange}
+                onValueChange={handleonValueChange}
                 prefix={prefix}
               />
               <div className="invalid-feedback">{state.field1.errorMessage}</div>
@@ -115,7 +115,7 @@ export const Example3: FC = () => {
                 name="field2"
                 className={`form-control ${state.field2.validationClass}`}
                 value={state.field2.value}
-                onChange={handleOnChange}
+                onValueChange={handleonValueChange}
                 prefix={prefix}
               />
               <div className="invalid-feedback">{state.field1.errorMessage}</div>


### PR DESCRIPTION
This is quite a big change, but I feel that it is more "correct" because it allows the user to access original onChange event

Breaking Change: Renamed "onChange" to "onValueChange"