### PR TITLE
test: replace enzyme with react testing library

### DIFF
--- a/.enzymerc.js
+++ b/.enzymerc.js
@@ -1,4 +1,0 @@
-const { configure } = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-configure({ adapter: new Adapter() });

--- a/package.json
+++ b/package.json
@@ -46,7 +46,10 @@
     "@commitlint/config-conventional": "^9.1.1",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
-    "@types/enzyme": "^3.10.5",
+    "@testing-library/dom": "^7.29.0",
+    "@testing-library/jest-dom": "^5.11.6",
+    "@testing-library/react": "^11.2.2",
+    "@testing-library/user-event": "^12.6.0",
     "@types/jest": "^26.0.9",
     "@types/react": "^16.9.46",
     "@types/react-dom": "^16.9.8",
@@ -55,8 +58,6 @@
     "awesome-typescript-loader": "^5.2.1",
     "codecov": "^3.7.2",
     "cross-env": "^7.0.3",
-    "enzyme": "^3.11.0",
-    "enzyme-adapter-react-16": "^1.15.3",
     "eslint": "^7.6.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
@@ -86,9 +87,6 @@
   "jest": {
     "verbose": false,
     "collectCoverage": true,
-    "setupFilesAfterEnv": [
-      "./.enzymerc.js"
-    ],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -35,31 +35,29 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       step,
       disableGroupSeparators = false,
       disableAbbreviations = false,
+      decimalSeparator: _decimalSeparator,
+      groupSeparator: _groupSeparator,
       onChange,
       onBlur,
       ...props
     }: CurrencyInputProps,
     ref
   ) => {
-    if (
-      props.decimalSeparator &&
-      props.groupSeparator &&
-      props.decimalSeparator === props.groupSeparator
-    ) {
+    if (_decimalSeparator && _groupSeparator && _decimalSeparator === _groupSeparator) {
       throw new Error('decimalSeparator cannot be the same as groupSeparator');
     }
 
-    if (props.decimalSeparator && isNumber(props.decimalSeparator)) {
+    if (_decimalSeparator && isNumber(_decimalSeparator)) {
       throw new Error('decimalSeparator cannot be a number');
     }
 
-    if (props.groupSeparator && isNumber(props.groupSeparator)) {
+    if (_groupSeparator && isNumber(_groupSeparator)) {
       throw new Error('groupSeparator cannot be a number');
     }
 
     const localeConfig = useMemo(() => getLocaleConfig(intlConfig), [intlConfig]);
-    const decimalSeparator = props.decimalSeparator || localeConfig.decimalSeparator || '';
-    const groupSeparator = props.groupSeparator || localeConfig.groupSeparator || '';
+    const decimalSeparator = _decimalSeparator || localeConfig.decimalSeparator || '';
+    const groupSeparator = _groupSeparator || localeConfig.groupSeparator || '';
 
     const formatValueOptions = {
       decimalSeparator,

--- a/src/components/__tests__/CurrencyInput-abbreviated.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-abbreviated.spec.tsx
@@ -1,10 +1,10 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import CurrencyInput from '../CurrencyInput';
 
-const id = 'validationCustom01';
-
-describe('<CurrencyInput /> component > abbreviated', () => {
+describe('<CurrencyInput/> abbreviated', () => {
   const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
@@ -12,63 +12,77 @@ describe('<CurrencyInput /> component > abbreviated', () => {
   });
 
   it('should allow abbreviated values with k', () => {
-    const view = shallow(<CurrencyInput id={id} prefix="£" onValueChange={onValueChangeSpy} />);
-    view.find(`#${id}`).simulate('change', { target: { value: '£1.5k' } });
+    render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '1.5k');
+
     expect(onValueChangeSpy).toBeCalledWith('1500', undefined);
 
-    expect(view.update().find(`#${id}`).prop('value')).toBe('£1,500');
+    expect(screen.getByRole('textbox')).toHaveValue('£1,500');
   });
 
   it('should allow abbreviated values with m', () => {
-    const view = shallow(<CurrencyInput id={id} prefix="£" onValueChange={onValueChangeSpy} />);
-    view.find(`#${id}`).simulate('change', { target: { value: '£2.123M' } });
-    expect(onValueChangeSpy).toBeCalledWith('2123000', undefined);
+    render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} decimalsLimit={3} />);
+    userEvent.type(screen.getByRole('textbox'), '2.123M');
+    userEvent.tab();
 
-    expect(view.update().find(`#${id}`).prop('value')).toBe('£2,123,000');
+    expect(screen.getByRole('textbox')).toHaveValue('£2,123,000');
+
+    expect(onValueChangeSpy).toBeCalledWith('2123000', undefined);
   });
 
   it('should allow abbreviated values with b', () => {
-    const view = shallow(<CurrencyInput id={id} prefix="£" onValueChange={onValueChangeSpy} />);
-    view.find(`#${id}`).simulate('change', { target: { value: '£1.599B' } });
+    render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} decimalsLimit={3} />);
+    userEvent.type(screen.getByRole('textbox'), '1.599B');
+
     expect(onValueChangeSpy).toBeCalledWith('1599000000', undefined);
 
-    expect(view.update().find(`#${id}`).prop('value')).toBe('£1,599,000,000');
+    expect(screen.getByRole('textbox')).toHaveValue('£1,599,000,000');
   });
 
   it('should not abbreviate any other letters', () => {
-    const view = shallow(<CurrencyInput id={id} prefix="£" onValueChange={onValueChangeSpy} />);
-    view.find(`#${id}`).simulate('change', { target: { value: '£1.5e' } });
+    render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '1.5e');
+
     expect(onValueChangeSpy).toBeCalledWith('1.5', undefined);
 
-    expect(view.update().find(`#${id}`).prop('value')).toBe('£1.5');
+    expect(screen.getByRole('textbox')).toHaveValue('£1.5');
   });
 
   it('should not allow abbreviation without number', () => {
-    const view = shallow(<CurrencyInput id={id} onValueChange={onValueChangeSpy} />);
-    view.find(`#${id}`).simulate('change', { target: { value: 'k' } });
-    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
-    expect(view.update().find(`#${id}`).prop('value')).toBe('');
+    render(<CurrencyInput onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), 'k');
 
-    view.find(`#${id}`).simulate('change', { target: { value: 'M' } });
     expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
-    expect(view.update().find(`#${id}`).prop('value')).toBe('');
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+
+    userEvent.type(screen.getByRole('textbox'), 'M');
+
+    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
   });
 
   describe('disableAbbreviations', () => {
     it('should not allow abbreviations if disableAbbreviations is true', () => {
-      const view = shallow(
-        <CurrencyInput id={id} onValueChange={onValueChangeSpy} disableAbbreviations />
-      );
-      view.find(`#${id}`).simulate('change', { target: { value: '1k' } });
-      expect(view.update().find(`#${id}`).prop('value')).toBe('1');
+      render(<CurrencyInput onValueChange={onValueChangeSpy} disableAbbreviations />);
+      userEvent.type(screen.getByRole('textbox'), '1k');
 
-      view.find(`#${id}`).simulate('change', { target: { value: '23m' } });
+      expect(screen.getByRole('textbox')).toHaveValue('1');
+
+      userEvent.clear(screen.getByRole('textbox'));
+      userEvent.type(screen.getByRole('textbox'), '23m');
+
       expect(onValueChangeSpy).toBeCalledWith('23', undefined);
-      expect(view.update().find(`#${id}`).prop('value')).toBe('23');
 
-      view.find(`#${id}`).simulate('change', { target: { value: '55b' } });
+      expect(screen.getByRole('textbox')).toHaveValue('23');
+
+      userEvent.clear(screen.getByRole('textbox'));
+      userEvent.type(screen.getByRole('textbox'), '55b');
+
       expect(onValueChangeSpy).toBeCalledWith('55', undefined);
-      expect(view.update().find(`#${id}`).prop('value')).toBe('55');
+
+      expect(screen.getByRole('textbox')).toHaveValue('55');
     });
   });
 });

--- a/src/components/__tests__/CurrencyInput-decimals.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-decimals.spec.tsx
@@ -1,10 +1,10 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import CurrencyInput from '../CurrencyInput';
 
-const id = 'validationCustom01';
-
-describe('<CurrencyInput /> component > decimals', () => {
+describe('<CurrencyInput/> decimals', () => {
   const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
@@ -12,42 +12,35 @@ describe('<CurrencyInput /> component > decimals', () => {
   });
 
   it('should allow value with decimals if allowDecimals is true', () => {
-    const view = shallow(
-      <CurrencyInput allowDecimals={true} id={id} prefix="£" onValueChange={onValueChangeSpy} />
-    );
-    view.find(`#${id}`).simulate('change', { target: { value: '£1,234.56' } });
+    render(<CurrencyInput allowDecimals={true} prefix="£" onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '1,234.56');
+
     expect(onValueChangeSpy).toBeCalledWith('1234.56', undefined);
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('£1,234.56');
+    expect(screen.getByRole('textbox')).toHaveValue('£1,234.56');
   });
 
   it('should disallow value with decimals if allowDecimals is false', () => {
-    const view = shallow(
-      <CurrencyInput allowDecimals={false} id={id} prefix="£" onValueChange={onValueChangeSpy} />
-    );
-    view.find(`#${id}`).simulate('change', { target: { value: '£1,234.56' } });
-    expect(onValueChangeSpy).toBeCalledWith('1234', undefined);
+    render(<CurrencyInput allowDecimals={false} prefix="£" onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '1,234.56');
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('£1,234');
+    expect(onValueChangeSpy).toBeCalledWith('123456', undefined);
+
+    expect(screen.getByRole('textbox')).toHaveValue('£123,456');
   });
 
   it('should limit decimals to decimalsLimit length', () => {
-    const view = shallow(
-      <CurrencyInput id={id} decimalsLimit={3} prefix="£" onValueChange={onValueChangeSpy} />
-    );
-    view.find(`#${id}`).simulate('change', { target: { value: '£1,234.56789' } });
+    render(<CurrencyInput decimalsLimit={3} prefix="£" onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '1,234.56789');
+
     expect(onValueChangeSpy).toBeCalledWith('1234.567', undefined);
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('£1,234.567');
+    expect(screen.getByRole('textbox')).toHaveValue('£1,234.567');
   });
 
   it('should be disabled if disabled prop is true', () => {
-    const view = shallow(
-      <CurrencyInput id={id} decimalsLimit={3} disabled={true} onValueChange={onValueChangeSpy} />
-    );
-    expect(view.find(`#${id}`).prop('disabled')).toBe(true);
+    render(<CurrencyInput decimalsLimit={3} disabled={true} onValueChange={onValueChangeSpy} />);
+
+    expect(screen.getByRole('textbox')).toBeDisabled();
   });
 });

--- a/src/components/__tests__/CurrencyInput-fixedDecimalLength.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-fixedDecimalLength.spec.tsx
@@ -1,10 +1,10 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import CurrencyInput from '../CurrencyInput';
 
-const id = 'validationCustom01';
-
-describe('<CurrencyInput /> component > fixedDecimalLength', () => {
+describe('<CurrencyInput/> fixedDecimalLength', () => {
   const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
@@ -13,9 +13,8 @@ describe('<CurrencyInput /> component > fixedDecimalLength', () => {
 
   describe('fixedDecimalLength', () => {
     it('should convert value on blur if fixedDecimalLength specified', () => {
-      const view = shallow(
+      render(
         <CurrencyInput
-          id={id}
           prefix="$"
           onValueChange={onValueChangeSpy}
           fixedDecimalLength={3}
@@ -23,38 +22,36 @@ describe('<CurrencyInput /> component > fixedDecimalLength', () => {
         />
       );
 
-      const input = view.find(`#${id}`);
-      expect(input.prop('value')).toBe('$123');
+      expect(screen.getByRole('textbox')).toHaveValue('$123');
 
-      view.find(`#${id}`).simulate('blur', { target: { value: '$123' } });
+      screen.getByRole('textbox').focus();
+      userEvent.tab();
+
       expect(onValueChangeSpy).toBeCalledWith('1.230', undefined);
 
-      const updatedView = view.update();
-      expect(updatedView.find(`#${id}`).prop('value')).toBe('$1.230');
+      expect(screen.getByRole('textbox')).toHaveValue('$1.230');
     });
 
     it('should work with decimalScale and decimalSeparator', () => {
-      const view = shallow(
+      render(
         <CurrencyInput
-          id={id}
           prefix="$"
           onValueChange={onValueChangeSpy}
           fixedDecimalLength={3}
-          groupSeparator="."
           decimalSeparator=","
           decimalScale={2}
           defaultValue={123}
         />
       );
 
-      const input = view.find(`#${id}`);
-      expect(input.prop('value')).toBe('$123');
+      expect(screen.getByRole('textbox')).toHaveValue('$123');
 
-      view.find(`#${id}`).simulate('blur', { target: { value: '$123' } });
+      screen.getByRole('textbox').focus();
+      userEvent.tab();
+
       expect(onValueChangeSpy).toBeCalledWith('1,23', undefined);
 
-      const updatedView = view.update();
-      expect(updatedView.find(`#${id}`).prop('value')).toBe('$1,23');
+      expect(screen.getByRole('textbox')).toHaveValue('$1,23');
     });
   });
 });

--- a/src/components/__tests__/CurrencyInput-handleKeyDown.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-handleKeyDown.spec.tsx
@@ -1,10 +1,10 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import CurrencyInput from '../CurrencyInput';
 
-const id = 'validationCustom01';
-
-describe('<CurrencyInput /> component > handleKeyDown', () => {
+describe('<CurrencyInput/> handleKeyDown', () => {
   const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
@@ -12,130 +12,101 @@ describe('<CurrencyInput /> component > handleKeyDown', () => {
   });
 
   it('should not change value if no step prop', () => {
-    const view = shallow(
-      <CurrencyInput id={id} prefix="£" defaultValue={100} onValueChange={onValueChangeSpy} />
-    );
+    render(<CurrencyInput prefix="£" defaultValue={100} onValueChange={onValueChangeSpy} />);
 
     // Arrow up
-    view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
+    userEvent.type(screen.getByRole('textbox'), '{arrowup}');
     expect(onValueChangeSpy).not.toBeCalled();
-    expect(view.update().find(`#${id}`).prop('value')).toBe('£100');
+    expect(screen.getByRole('textbox')).toHaveValue('£100');
 
     // Arrow down
-    view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
+    userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
     expect(onValueChangeSpy).not.toBeCalled();
-    expect(view.update().find(`#${id}`).prop('value')).toBe('£100');
+    expect(screen.getByRole('textbox')).toHaveValue('£100');
   });
 
   it('should handle negative step', () => {
-    const view = shallow(
-      <CurrencyInput
-        id={id}
-        prefix="£"
-        defaultValue={100}
-        step={-2}
-        onValueChange={onValueChangeSpy}
-      />
+    render(
+      <CurrencyInput prefix="£" defaultValue={100} step={-2} onValueChange={onValueChangeSpy} />
     );
 
-    view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
+    userEvent.type(screen.getByRole('textbox'), '{arrowup}');
     expect(onValueChangeSpy).toHaveBeenCalledWith('98', undefined);
-    expect(view.update().find(`#${id}`).prop('value')).toBe('£98');
+    expect(screen.getByRole('textbox')).toHaveValue('£98');
 
-    view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
+    userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
     expect(onValueChangeSpy).toHaveBeenCalledWith('100', undefined);
-    expect(view.update().find(`#${id}`).prop('value')).toBe('£100');
+    expect(screen.getByRole('textbox')).toHaveValue('£100');
   });
 
   describe('without value ie. default 0', () => {
     it('should handle arrow down key', () => {
-      const view = shallow(
-        <CurrencyInput id={id} prefix="£" step={1} onValueChange={onValueChangeSpy} />
-      );
+      render(<CurrencyInput prefix="£" step={1} onValueChange={onValueChangeSpy} />);
 
-      view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
+      userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
       expect(onValueChangeSpy).toBeCalledWith('-1', undefined);
-      expect(view.update().find(`#${id}`).prop('value')).toBe('-£1');
+      expect(screen.getByRole('textbox')).toHaveValue('-£1');
     });
 
     it('should handle arrow down key', () => {
-      const view = shallow(
-        <CurrencyInput id={id} prefix="£" step={1} onValueChange={onValueChangeSpy} />
-      );
+      render(<CurrencyInput prefix="£" step={1} onValueChange={onValueChangeSpy} />);
 
-      view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
+      userEvent.type(screen.getByRole('textbox'), '{arrowup}');
       expect(onValueChangeSpy).toBeCalledWith('1', undefined);
-      expect(view.update().find(`#${id}`).prop('value')).toBe('£1');
+      expect(screen.getByRole('textbox')).toHaveValue('£1');
     });
   });
 
   describe('with value 99 and step 1.25', () => {
     it('should handle arrow down key', () => {
-      const view = shallow(
-        <CurrencyInput id={id} prefix="£" value={99} step={1.25} onValueChange={onValueChangeSpy} />
-      );
+      render(<CurrencyInput prefix="£" value={99} step={1.25} onValueChange={onValueChangeSpy} />);
 
-      view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
+      userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
       expect(onValueChangeSpy).toHaveBeenCalledWith('97.75', undefined);
     });
 
     it('should handle arrow up key', () => {
-      const view = shallow(
-        <CurrencyInput id={id} prefix="£" value={99} step={1.25} onValueChange={onValueChangeSpy} />
-      );
+      render(<CurrencyInput prefix="£" value={99} step={1.25} onValueChange={onValueChangeSpy} />);
 
-      view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
+      userEvent.type(screen.getByRole('textbox'), '{arrowup}');
       expect(onValueChangeSpy).toHaveBeenCalledWith('100.25', undefined);
     });
   });
 
   describe('with defaultValue 100 and step 5.5', () => {
     it('should handle arrow down key', () => {
-      const view = shallow(
-        <CurrencyInput
-          id={id}
-          prefix="£"
-          defaultValue={100}
-          step={5.5}
-          onValueChange={onValueChangeSpy}
-        />
+      render(
+        <CurrencyInput prefix="£" defaultValue={100} step={5.5} onValueChange={onValueChangeSpy} />
       );
 
-      view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
+      userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
       expect(onValueChangeSpy).toBeCalledWith('94.5', undefined);
-      expect(view.update().find(`#${id}`).prop('value')).toBe('£94.5');
+      expect(screen.getByRole('textbox')).toHaveValue('£94.5');
 
-      view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
+      userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
       expect(onValueChangeSpy).toBeCalledWith('89', undefined);
-      expect(view.update().find(`#${id}`).prop('value')).toBe('£89');
+      expect(screen.getByRole('textbox')).toHaveValue('£89');
     });
 
     it('should handle arrow up key', () => {
-      const view = shallow(
-        <CurrencyInput
-          id={id}
-          prefix="£"
-          defaultValue={100}
-          step={5.5}
-          onValueChange={onValueChangeSpy}
-        />
+      render(
+        <CurrencyInput prefix="£" defaultValue={100} step={5.5} onValueChange={onValueChangeSpy} />
       );
 
-      view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
+      userEvent.type(screen.getByRole('textbox'), '{arrowup}');
       expect(onValueChangeSpy).toBeCalledWith('105.5', undefined);
-      expect(view.update().find(`#${id}`).prop('value')).toBe('£105.5');
+      expect(screen.getByRole('textbox')).toHaveValue('£105.5');
 
-      view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
+      userEvent.type(screen.getByRole('textbox'), '{arrowup}');
       expect(onValueChangeSpy).toBeCalledWith('111', undefined);
-      expect(view.update().find(`#${id}`).prop('value')).toBe('£111');
+      expect(screen.getByRole('textbox')).toHaveValue('£111');
     });
   });
 
   describe('with max length 2', () => {
     it('should handle negative value', () => {
-      const view = shallow(
+      render(
         <CurrencyInput
-          id={id}
           prefix="£"
           defaultValue={-99}
           step={1}
@@ -144,19 +115,18 @@ describe('<CurrencyInput /> component > handleKeyDown', () => {
         />
       );
 
-      view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
+      userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
       expect(onValueChangeSpy).not.toBeCalled();
-      expect(view.update().find(`#${id}`).prop('value')).toBe('-£99');
+      expect(screen.getByRole('textbox')).toHaveValue('-£99');
 
-      view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
+      userEvent.type(screen.getByRole('textbox'), '{arrowup}');
       expect(onValueChangeSpy).toHaveBeenCalledWith('-98', undefined);
-      expect(view.update().find(`#${id}`).prop('value')).toBe('-£98');
+      expect(screen.getByRole('textbox')).toHaveValue('-£98');
     });
 
     it('should handle positive value', () => {
-      const view = shallow(
+      render(
         <CurrencyInput
-          id={id}
           prefix="£"
           defaultValue={99}
           step={1}
@@ -165,13 +135,13 @@ describe('<CurrencyInput /> component > handleKeyDown', () => {
         />
       );
 
-      view.find(`#${id}`).simulate('keyDown', { key: 'ArrowUp' });
+      userEvent.type(screen.getByRole('textbox'), '{arrowup}');
       expect(onValueChangeSpy).not.toBeCalled();
-      expect(view.update().find(`#${id}`).prop('value')).toBe('£99');
+      expect(screen.getByRole('textbox')).toHaveValue('£99');
 
-      view.find(`#${id}`).simulate('keyDown', { key: 'ArrowDown' });
+      userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
       expect(onValueChangeSpy).toHaveBeenCalledWith('98', undefined);
-      expect(view.update().find(`#${id}`).prop('value')).toBe('£98');
+      expect(screen.getByRole('textbox')).toHaveValue('£98');
     });
   });
 });

--- a/src/components/__tests__/CurrencyInput-intl-config.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-intl-config.spec.tsx
@@ -1,33 +1,39 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
 import CurrencyInput from '../CurrencyInput';
 
 const id = 'validationCustom01';
 
-describe('<CurrencyInput /> component > intlConfig', () => {
+describe('<CurrencyInput/> intlConfig', () => {
   it('should use intl config settings (en-US, USD)', () => {
-    const view = shallow(
+    render(
       <CurrencyInput id={id} intlConfig={{ locale: 'en-US', currency: 'USD' }} value="123456789" />
     );
-    expect(view.find(`#${id}`).prop('value')).toBe('$123,456,789');
+
+    expect(screen.getByRole('textbox')).toHaveValue('$123,456,789');
   });
 
   it('should use intl config settings (en-IN, INR)', () => {
-    const view = shallow(
+    render(
       <CurrencyInput id={id} intlConfig={{ locale: 'en-IN', currency: 'INR' }} value="500000" />
     );
-    expect(view.find(`#${id}`).prop('value')).toBe('₹5,00,000');
+
+    expect(screen.getByRole('textbox')).toHaveValue('₹5,00,000');
   });
 
   it('should use intl config settings (ja-JP, JPY)', () => {
-    const view = shallow(
+    render(
       <CurrencyInput id={id} intlConfig={{ locale: 'ja-JP', currency: 'JPY' }} value="123.456" />
     );
-    expect(view.find(`#${id}`).prop('value')).toBe('￥123');
+
+    expect(screen.getByRole('textbox')).toHaveValue('￥123');
   });
 
   it('should override locale currency symbol if prefix passed in', () => {
-    const view = shallow(
+    render(
       <CurrencyInput
         id={id}
         intlConfig={{ locale: 'en-US', currency: 'USD' }}
@@ -35,11 +41,12 @@ describe('<CurrencyInput /> component > intlConfig', () => {
         prefix="£"
       />
     );
-    expect(view.find(`#${id}`).prop('value')).toBe('£100');
+
+    expect(screen.getByRole('textbox')).toHaveValue('£100');
   });
 
   it('should override locale group separator if groupSeparator passed in', () => {
-    const view = shallow(
+    render(
       <CurrencyInput
         id={id}
         intlConfig={{ locale: 'en-US', currency: 'USD' }}
@@ -47,11 +54,12 @@ describe('<CurrencyInput /> component > intlConfig', () => {
         groupSeparator="/"
       />
     );
-    expect(view.find(`#${id}`).prop('value')).toBe('$123/456/789.99');
+
+    expect(screen.getByRole('textbox')).toHaveValue('$123/456/789.99');
   });
 
   it('should override locale decimal separator if decimalSeparator passed in', () => {
-    const view = shallow(
+    render(
       <CurrencyInput
         id={id}
         intlConfig={{ locale: 'en-US', currency: 'USD' }}
@@ -59,7 +67,8 @@ describe('<CurrencyInput /> component > intlConfig', () => {
         decimalSeparator="-"
       />
     );
-    expect(view.find(`#${id}`).prop('value')).toBe('$123,456-789');
+
+    expect(screen.getByRole('textbox')).toHaveValue('$123,456-789');
   });
 
   describe('onValueChange', () => {
@@ -70,20 +79,21 @@ describe('<CurrencyInput /> component > intlConfig', () => {
     });
 
     it('should handle onValueChange with intl config settings (en-IN, INR)', () => {
-      const view = shallow(
+      render(
         <CurrencyInput
           id={id}
           intlConfig={{ locale: 'en-IN', currency: 'INR' }}
           onValueChange={onValueChangeSpy}
         />
       );
-      expect(view.find(`#${id}`).prop('value')).toBe('');
 
-      view.find(`#${id}`).simulate('change', { target: { value: '₹12,34,567' } });
+      expect(screen.getByRole('textbox')).toHaveValue('');
+
+      userEvent.type(screen.getByRole('textbox'), '₹12,34,567');
+
       expect(onValueChangeSpy).toBeCalledWith('1234567', undefined);
 
-      const updatedView = view.update();
-      expect(updatedView.find(`#${id}`).prop('value')).toBe('₹12,34,567');
+      expect(screen.getByRole('textbox')).toHaveValue('₹12,34,567');
     });
   });
 });

--- a/src/components/__tests__/CurrencyInput-maxLength.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-maxLength.spec.tsx
@@ -1,10 +1,10 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import CurrencyInput from '../CurrencyInput';
 
-const id = 'validationCustom01';
-
-describe('<CurrencyInput /> component > maxLength', () => {
+describe('<CurrencyInput/> maxLength', () => {
   const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
@@ -12,32 +12,21 @@ describe('<CurrencyInput /> component > maxLength', () => {
   });
 
   it('should not allow more values than max length', () => {
-    const view = shallow(
-      <CurrencyInput
-        id={id}
-        name={name}
-        prefix="£"
-        onValueChange={onValueChangeSpy}
-        maxLength={3}
-        defaultValue={123}
-      />
+    render(
+      <CurrencyInput prefix="£" onValueChange={onValueChangeSpy} maxLength={3} defaultValue={123} />
     );
 
-    const input = view.find(`#${id}`);
-    expect(input.prop('value')).toBe('£123');
+    expect(screen.getByRole('textbox')).toHaveValue('£123');
 
-    input.simulate('change', { target: { value: '£1234' } });
+    userEvent.type(screen.getByRole('textbox'), '4');
     expect(onValueChangeSpy).not.toBeCalled();
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('£123');
+    expect(screen.getByRole('textbox')).toHaveValue('£123');
   });
 
   it('should apply max length rule to negative value', () => {
-    const view = shallow(
+    render(
       <CurrencyInput
-        id={id}
-        name={name}
         prefix="£"
         onValueChange={onValueChangeSpy}
         maxLength={3}
@@ -45,15 +34,14 @@ describe('<CurrencyInput /> component > maxLength', () => {
       />
     );
 
-    const input = view.find(`#${id}`);
-    expect(input.prop('value')).toBe('-£123');
+    expect(screen.getByRole('textbox')).toHaveValue('-£123');
 
-    input.simulate('change', { target: { value: '-£1234' } });
+    userEvent.type(screen.getByRole('textbox'), '4');
     expect(onValueChangeSpy).not.toBeCalled();
-    expect(view.update().find(`#${id}`).prop('value')).toBe('-£123');
+    expect(screen.getByRole('textbox')).toHaveValue('-£123');
 
-    input.simulate('change', { target: { value: '-£125' } });
-    expect(onValueChangeSpy).toHaveBeenCalledWith('-125', '');
-    expect(view.update().find(`#${id}`).prop('value')).toBe('-£125');
+    userEvent.type(screen.getByRole('textbox'), '{backspace}5');
+    expect(onValueChangeSpy).toHaveBeenCalledWith('-125', undefined);
+    expect(screen.getByRole('textbox')).toHaveValue('-£125');
   });
 });

--- a/src/components/__tests__/CurrencyInput-negative.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-negative.spec.tsx
@@ -1,10 +1,12 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import CurrencyInput from '../CurrencyInput';
 
 const id = 'validationCustom01';
 
-describe('<CurrencyInput /> component > negative value', () => {
+describe('<CurrencyInput/> negative value', () => {
   const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
@@ -12,7 +14,7 @@ describe('<CurrencyInput /> component > negative value', () => {
   });
 
   it('should handle negative value input', () => {
-    const view = shallow(
+    render(
       <CurrencyInput
         id={id}
         prefix="$"
@@ -22,18 +24,17 @@ describe('<CurrencyInput /> component > negative value', () => {
       />
     );
 
-    const input = view.find(`#${id}`);
-    expect(input.prop('value')).toBe('$123');
+    expect(screen.getByRole('textbox')).toHaveValue('$123');
 
-    input.simulate('change', { target: { value: '-$1234' } });
+    userEvent.clear(screen.getByRole('textbox'));
+    userEvent.type(screen.getByRole('textbox'), '-1234');
     expect(onValueChangeSpy).toBeCalledWith('-1234', undefined);
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('-$1,234');
+    expect(screen.getByRole('textbox')).toHaveValue('-$1,234');
   });
 
   it('should call onValueChange with undefined and keep "-" sign as state value', () => {
-    const view = shallow(
+    render(
       <CurrencyInput
         id={id}
         prefix="$"
@@ -43,18 +44,17 @@ describe('<CurrencyInput /> component > negative value', () => {
       />
     );
 
-    const input = view.find(`#${id}`);
-    expect(input.prop('value')).toBe('$123');
+    expect(screen.getByRole('textbox')).toHaveValue('$123');
 
-    input.simulate('change', { target: { value: '-' } });
+    userEvent.clear(screen.getByRole('textbox'));
+    userEvent.type(screen.getByRole('textbox'), '-');
     expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('-');
+    expect(screen.getByRole('textbox')).toHaveValue('-');
   });
 
   it('should not call onBlur if only negative sign and clears value', () => {
-    const view = shallow(
+    render(
       <CurrencyInput
         id={id}
         prefix="$"
@@ -64,18 +64,19 @@ describe('<CurrencyInput /> component > negative value', () => {
       />
     );
 
-    const input = view.find(`#${id}`);
-    expect(input.prop('value')).toBe('$123');
+    expect(screen.getByRole('textbox')).toHaveValue('$123');
 
-    input.simulate('blur', { target: { value: '-' } });
-    expect(onValueChangeSpy).not.toBeCalled();
+    userEvent.type(screen.getByRole('textbox'), '{backspace}{backspace}{backspace}{backspace}-');
+    expect(screen.getByRole('textbox')).toHaveValue('-');
+    expect(onValueChangeSpy).toBeCalledTimes(4);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith(undefined, undefined);
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('');
+    userEvent.tab();
+    expect(screen.getByRole('textbox')).toHaveValue('');
   });
 
   it('should not allow negative value if allowNegativeValue is false', () => {
-    const view = shallow(
+    render(
       <CurrencyInput
         id={id}
         prefix="$"
@@ -85,13 +86,12 @@ describe('<CurrencyInput /> component > negative value', () => {
       />
     );
 
-    const input = view.find(`#${id}`);
-    expect(input.prop('value')).toBe('$123');
+    expect(screen.getByRole('textbox')).toHaveValue('$123');
 
-    input.simulate('change', { target: { value: '-$1234' } });
+    userEvent.clear(screen.getByRole('textbox'));
+    userEvent.type(screen.getByRole('textbox'), '-1234');
     expect(onValueChangeSpy).toBeCalledWith('1234', undefined);
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('$1,234');
+    expect(screen.getByRole('textbox')).toHaveValue('$1,234');
   });
 });

--- a/src/components/__tests__/CurrencyInput-no-locale.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-no-locale.spec.tsx
@@ -1,5 +1,6 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 import CurrencyInput from '../CurrencyInput';
 import { getLocaleConfig } from '../utils';
 
@@ -7,12 +8,10 @@ jest.mock('../utils/getLocaleConfig', () => ({
   getLocaleConfig: jest.fn().mockReturnValue({ groupSeparator: ',', decimalSeparator: '.' }),
 }));
 
-const id = 'validationCustom01';
-
-describe('<CurrencyInput /> component > no locale', () => {
+describe('<CurrencyInput/> no locale', () => {
   it('should have empty string for groupSeparator and decimalSeparator if not passed in and cannot find default locale', () => {
     (getLocaleConfig as jest.Mock).mockReturnValue({ groupSeparator: '', decimalSeparator: '' });
-    const view = shallow(<CurrencyInput id={id} value="123456789" />);
-    expect(view.find(`#${id}`).prop('value')).toBe('123456789');
+    render(<CurrencyInput value="123456789" />);
+    expect(screen.getByRole('textbox')).toHaveValue('123456789');
   });
 });

--- a/src/components/__tests__/CurrencyInput-onBlur.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-onBlur.spec.tsx
@@ -1,11 +1,13 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
 import CurrencyInput from '../CurrencyInput';
 
-const id = 'validationCustom01';
 const name = 'inputName';
 
-describe('<CurrencyInput /> component > onBlur', () => {
+describe('<CurrencyInput/> onBlur', () => {
   const onBlurSpy = jest.fn();
   const onValueChangeSpy = jest.fn();
 
@@ -14,9 +16,8 @@ describe('<CurrencyInput /> component > onBlur', () => {
   });
 
   it('should call onBlur and onValueChange', () => {
-    const view = shallow(
+    render(
       <CurrencyInput
-        id={id}
         name={name}
         prefix="$"
         onBlur={onBlurSpy}
@@ -24,42 +25,47 @@ describe('<CurrencyInput /> component > onBlur', () => {
         decimalScale={2}
       />
     );
-    const event = { target: { value: '123' } };
-    view.find(`#${id}`).simulate('blur', event);
-    expect(onBlurSpy).toBeCalledWith(event);
+
+    userEvent.type(screen.getByRole('textbox'), '123');
+    userEvent.tab();
+
+    expect(onBlurSpy).toBeCalled();
+
     expect(onValueChangeSpy).toBeCalledWith('123.00', name);
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('$123.00');
+    expect(screen.getByRole('textbox')).toHaveValue('$123.00');
   });
 
   it('should call onBlur for 0', () => {
-    const view = shallow(<CurrencyInput id={id} name={name} prefix="$" onBlur={onBlurSpy} />);
-    const event = { target: { value: '0' } };
-    view.find(`#${id}`).simulate('blur', event);
-    expect(onBlurSpy).toBeCalledWith(event);
+    render(<CurrencyInput name={name} prefix="$" onBlur={onBlurSpy} />);
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('$0');
+    userEvent.type(screen.getByRole('textbox'), '0');
+    userEvent.tab();
+
+    expect(onBlurSpy).toBeCalled();
+
+    expect(screen.getByRole('textbox')).toHaveValue('$0');
   });
 
   it('should call onBlur for empty value', () => {
-    const view = shallow(<CurrencyInput id={id} name={name} prefix="$" onBlur={onBlurSpy} />);
-    const event = { target: { value: '' } };
-    view.find(`#${id}`).simulate('blur', event);
-    expect(onBlurSpy).toBeCalledWith(event);
+    render(<CurrencyInput name={name} prefix="$" onBlur={onBlurSpy} />);
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('');
+    userEvent.type(screen.getByRole('textbox'), '');
+    userEvent.tab();
+
+    expect(onBlurSpy).toBeCalled();
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
   });
 
   it('should call onBlur for "-" char', () => {
-    const view = shallow(<CurrencyInput id={id} name={name} prefix="$" onBlur={onBlurSpy} />);
-    const event = { target: { value: '-' } };
-    view.find(`#${id}`).simulate('blur', event);
-    expect(onBlurSpy).toBeCalledWith(event);
+    render(<CurrencyInput name={name} prefix="$" onBlur={onBlurSpy} />);
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('');
+    userEvent.type(screen.getByRole('textbox'), '-');
+    userEvent.tab();
+
+    expect(onBlurSpy).toBeCalled();
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
   });
 });

--- a/src/components/__tests__/CurrencyInput-precision.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-precision.spec.tsx
@@ -1,10 +1,10 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import CurrencyInput from '../CurrencyInput';
 
-const id = 'validationCustom01';
-
-describe('<CurrencyInput /> component > decimalScale', () => {
+describe('<CurrencyInput/> decimalScale', () => {
   const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
@@ -12,34 +12,32 @@ describe('<CurrencyInput /> component > decimalScale', () => {
   });
 
   it('should pad to decimalScale of 5 on blur', () => {
-    const view = shallow(
-      <CurrencyInput id={id} prefix="£" onValueChange={onValueChangeSpy} decimalScale={5} />
-    );
-    view.find(`#${id}`).simulate('blur', { target: { value: '£1.5' } });
+    render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} decimalScale={5} />);
+
+    userEvent.type(screen.getByRole('textbox'), '1.5');
+    userEvent.tab();
     expect(onValueChangeSpy).toBeCalledWith('1.50000', undefined);
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('£1.50000');
+    expect(screen.getByRole('textbox')).toHaveValue('£1.50000');
   });
 
   it('should pad to decimalScale of 2 on blur', () => {
     const onBlurSpy = jest.fn();
-    const view = shallow(
+    render(
       <CurrencyInput
-        id={id}
         prefix="£"
         onValueChange={onValueChangeSpy}
         onBlur={onBlurSpy}
         decimalScale={2}
       />
     );
-    const event = { target: { value: '£1' } };
 
-    view.find(`#${id}`).simulate('blur', event);
-    expect(onBlurSpy).toBeCalledWith(event);
+    userEvent.type(screen.getByRole('textbox'), '1');
+    userEvent.tab();
+    expect(onBlurSpy).toBeCalled();
+
     expect(onValueChangeSpy).toBeCalledWith('1.00', undefined);
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('£1.00');
+    expect(screen.getByRole('textbox')).toHaveValue('£1.00');
   });
 });

--- a/src/components/__tests__/CurrencyInput.spec.tsx
+++ b/src/components/__tests__/CurrencyInput.spec.tsx
@@ -1,13 +1,10 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import CurrencyInput from '../CurrencyInput';
 
-const id = 'validationCustom01';
-const className = 'form-control';
-const placeholder = '£1,000';
-const name = 'inputName';
-
-describe('<CurrencyInput /> component', () => {
+describe('<CurrencyInput/>', () => {
   const onValueChangeSpy = jest.fn();
 
   beforeEach(() => {
@@ -15,147 +12,128 @@ describe('<CurrencyInput /> component', () => {
   });
 
   it('Renders without error', () => {
-    const view = shallow(
-      <CurrencyInput id={id} name={name} placeholder={placeholder} className={className} />
+    render(
+      <CurrencyInput
+        id="validationCustom01"
+        name="inputName"
+        placeholder="£1,000"
+        className="form-control"
+      />
     );
-    const input = view.find(`#${id}`);
+    const input = screen.getByRole('textbox');
 
     expect(input).toMatchSnapshot();
-    expect(input.prop('id')).toBe(id);
-    expect(input.prop('name')).toBe(name);
-    expect(input.prop('placeholder')).toBe(placeholder);
-    expect(input.prop('className')).toBe(className);
+
+    expect(input).toHaveValue('');
   });
 
   it('Renders with default value', () => {
-    const view = shallow(
-      <CurrencyInput id={id} defaultValue={1234.56} className={className} prefix="£" />
-    );
-    const input = view.find(`#${id}`);
+    render(<CurrencyInput defaultValue={1234.56} prefix="£" />);
+    const input = screen.getByRole('textbox');
 
-    expect(view.html()).toMatchSnapshot();
-    expect(input.prop('id')).toBe(id);
-    expect(input.prop('value')).toBe('£1,234.56');
-    expect(input.prop('className')).toBe(className);
+    expect(input).toMatchSnapshot();
+
+    expect(input).toHaveValue('£1,234.56');
   });
 
   it('Renders with default value 0', () => {
-    const view = shallow(
-      <CurrencyInput id={id} defaultValue={0} className={className} prefix="£" />
-    );
-    const input = view.find(`#${id}`);
-    expect(input.prop('value')).toBe('£0');
+    render(<CurrencyInput defaultValue={0} prefix="£" />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('£0');
   });
 
   it('Renders with value prop', () => {
-    const view = shallow(<CurrencyInput id={id} value={49.99} className={className} prefix="£" />);
-    const input = view.find(`#${id}`);
+    render(<CurrencyInput value={49.99} prefix="£" />);
 
-    expect(input.prop('value')).toBe('£49.99');
+    expect(screen.getByRole('textbox')).toHaveValue('£49.99');
   });
 
   it('Renders with value 0', () => {
-    const view = shallow(<CurrencyInput id={id} value={0} className={className} prefix="£" />);
-    const input = view.find(`#${id}`);
+    render(<CurrencyInput value={0} prefix="£" />);
 
-    expect(input.prop('value')).toBe('£0');
+    expect(screen.getByRole('textbox')).toHaveValue('£0');
   });
 
   it('should go to end of string on focus', () => {
-    const view = shallow(<CurrencyInput id={id} defaultValue={123} />);
-    view.find(`#${id}`).simulate('focus');
+    render(<CurrencyInput defaultValue={123} />);
+    userEvent.type(screen.getByRole('textbox'), '{arrowleft}4{arrowright}6');
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('123');
-  });
-
-  it('should go to beginning on focus if no value', () => {
-    const view = shallow(<CurrencyInput id={id} />);
-    view.find(`#${id}`).simulate('focus');
-
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('');
+    expect(screen.getByRole('textbox')).toHaveValue('12,436');
   });
 
   it('should allow value change with number', () => {
-    const view = shallow(<CurrencyInput id={id} prefix="£" onValueChange={onValueChangeSpy} />);
-    view.find(`#${id}`).simulate('change', { target: { value: '100' } });
+    render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '100');
 
     expect(onValueChangeSpy).toBeCalledWith('100', undefined);
   });
 
   it('should prefix 0 value', () => {
-    const view = shallow(
-      <CurrencyInput id={id} name={name} prefix="£" value={0} onValueChange={onValueChangeSpy} />
-    );
-    expect(view.find(`#${id}`).prop('value')).toBe('£0');
+    render(<CurrencyInput prefix="£" value={0} onValueChange={onValueChangeSpy} />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('£0');
   });
 
   it('should allow 0 value on change', () => {
-    const view = shallow(
-      <CurrencyInput id={id} name={name} prefix="£" onValueChange={onValueChangeSpy} />
-    );
-    view.find(`#${id}`).simulate('change', { target: { value: '0' } });
-    expect(onValueChangeSpy).toBeCalledWith('0', name);
+    render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '0');
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('£0');
+    expect(onValueChangeSpy).toBeCalledWith('0', undefined);
+
+    expect(screen.getByRole('textbox')).toHaveValue('£0');
   });
 
   it('should allow empty value', () => {
-    const view = shallow(
-      <CurrencyInput id={id} name={name} prefix="£" onValueChange={onValueChangeSpy} />
-    );
-    view.find(`#${id}`).simulate('change', { target: { value: '' } });
-    expect(onValueChangeSpy).toBeCalledWith(undefined, name);
+    render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} defaultValue={1} />);
+    userEvent.clear(screen.getByRole('textbox'));
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('');
+    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
   });
 
   it('should callback name as second parameter if name prop provided', () => {
-    const view = shallow(
-      <CurrencyInput id={id} name={name} prefix="£" onValueChange={onValueChangeSpy} />
-    );
-    view.find(`#${id}`).simulate('change', { target: { value: '£123' } });
+    const name = 'inputName';
+    render(<CurrencyInput name={name} prefix="£" onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '123');
+
     expect(onValueChangeSpy).toBeCalledWith('123', name);
   });
 
   it('should not allow invalid characters', () => {
-    const view = shallow(
-      <CurrencyInput id={id} name={name} prefix="£" onValueChange={onValueChangeSpy} />
-    );
-    view.find(`#${id}`).simulate('change', { target: { value: 'hello' } });
-    expect(onValueChangeSpy).toBeCalledWith(undefined, name);
+    render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), 'hello');
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('');
+    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
   });
 
   it('should ignore invalid characters', () => {
-    const view = shallow(
-      <CurrencyInput id={id} name={name} prefix="£" onValueChange={onValueChangeSpy} />
-    );
-    view.find(`#${id}`).simulate('change', { target: { value: '£123hello' } });
-    expect(onValueChangeSpy).toBeCalledWith('123', name);
+    render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '£123hello');
 
-    const updatedView = view.update();
-    expect(updatedView.find(`#${id}`).prop('value')).toBe('£123');
+    expect(onValueChangeSpy).toBeCalledWith('123', undefined);
+
+    expect(screen.getByRole('textbox')).toHaveValue('£123');
   });
 
-  it('should call onChange with raw onChange event', () => {
+  it('should call onChange', () => {
     const onChangeSpy = jest.fn();
-    const view = shallow(<CurrencyInput id={id} prefix="£" onChange={onChangeSpy} />);
-    const event = { target: { value: '£123' } };
-    view.find(`#${id}`).simulate('change', event);
-    expect(onChangeSpy).toBeCalledWith(event);
+    render(<CurrencyInput prefix="£" onChange={onChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '123');
+
+    expect(onChangeSpy).toBeCalledTimes(3);
+
+    expect(screen.getByRole('textbox')).toHaveValue('£123');
   });
 
-  it('should call onBlur with raw onBlur event', () => {
+  it('should call onBlur', () => {
     const onBlurSpy = jest.fn();
-    const view = shallow(<CurrencyInput id={id} prefix="£" onBlur={onBlurSpy} />);
-    const event = { target: { value: '£123' } };
-    view.find(`#${id}`).simulate('blur', event);
-    expect(onBlurSpy).toBeCalledWith(event);
+    render(<CurrencyInput prefix="£" onBlur={onBlurSpy} />);
+    userEvent.click(screen.getByRole('textbox'));
+    userEvent.tab();
+
+    expect(onBlurSpy).toBeCalledTimes(1);
   });
 });

--- a/src/components/__tests__/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<CurrencyInput /> component Renders with default value 1`] = `"<input type=\\"text\\" inputMode=\\"decimal\\" id=\\"validationCustom01\\" class=\\"form-control\\" value=\\"£1,234.56\\"/>"`;
+exports[`<CurrencyInput/> Renders with default value 1`] = `
+<input
+  inputmode="decimal"
+  type="text"
+  value="£1,234.56"
+/>
+`;
 
-exports[`<CurrencyInput /> component Renders without error 1`] = `ShallowWrapper {}`;
+exports[`<CurrencyInput/> Renders without error 1`] = `
+<input
+  class="form-control"
+  id="validationCustom01"
+  inputmode="decimal"
+  name="inputName"
+  placeholder="£1,000"
+  type="text"
+  value=""
+/>
+`;

--- a/src/components/utils/__tests__/formatValue.spec.ts
+++ b/src/components/utils/__tests__/formatValue.spec.ts
@@ -77,7 +77,7 @@ describe('formatValue', () => {
     ).toEqual('£123');
   });
 
-  it('should include "."', () => {
+  it('should include decimal separator if last char', () => {
     expect(
       formatValue({
         value: '1234567.',
@@ -85,6 +85,14 @@ describe('formatValue', () => {
         decimalSeparator: '.',
       })
     ).toEqual('1,234,567.');
+
+    expect(
+      formatValue({
+        value: '1234567,',
+        groupSeparator: '.',
+        decimalSeparator: ',',
+      })
+    ).toEqual('1.234.567,');
   });
 
   it('should include decimals', () => {

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -81,7 +81,8 @@ export const formatValue = (options: FormatValueOptions): string => {
   }
 
   // Include decimal separator if user input ends with decimal separator
-  const includeDecimalSeparator = value.slice(-1) === decimalSeparator ? decimalSeparator : '';
+  const includeDecimalSeparator =
+    String(_value).slice(-1) === decimalSeparator ? decimalSeparator : '';
 
   const [, decimals] = value.match(RegExp('\\d+\\.(\\d+)')) || [];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,6 +199,21 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz#ffee91da0eb4c6dae080774e94ba606368e414f4"
+  integrity sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.9.2":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.7":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
@@ -618,6 +633,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -849,6 +875,49 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@testing-library/dom@^7.28.1", "@testing-library/dom@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.0.tgz#60b18065bab50a5cde21fe80275a47a43024d9cc"
+  integrity sha512-0hhuJSmw/zLc6ewR9cVm84TehuTd7tbqBX9pRNSp8znJ9gTmSgesdbiGZtt8R6dL+2rgaPFp9Yjr7IU1HWm49w==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
+"@testing-library/jest-dom@^5.11.6":
+  version "5.11.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.6.tgz#782940e82e5cd17bc0a36f15156ba16f3570ac81"
+  integrity sha512-cVZyUNRWwUKI0++yepYpYX7uhrP398I+tGz4zOlLVlUYnZS+Svuxv4fwLeCIy7TnBYKXUaOlQr3vopxL8ZfEnA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
+"@testing-library/react@^11.2.2":
+  version "11.2.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.2.tgz#099c6c195140ff069211143cb31c0f8337bdb7b7"
+  integrity sha512-jaxm0hwUjv+hzC+UFEywic7buDC9JQ1q3cDsrWVSDAPmLotfA6E6kUHlYm/zOeGCac6g48DR36tFHxl7Zb+N5A==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^7.28.1"
+
+"@testing-library/user-event@^12.6.0":
+  version "12.6.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.6.0.tgz#2d0229e399eb5a0c6c112e848611432356cac886"
+  integrity sha512-FNEH/HLmOk5GO70I52tKjs7WvGYckeE/SrnLX/ip7z2IGbffyd5zOUM1tZ10vsTphqm+VbDFI0oaXu0wcfQsAQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@tootallnate/once@1":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.0.0.tgz#9c13c2574c92d4503b005feca8f2e16cc1611506"
@@ -858,6 +927,11 @@
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
+  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
 "@types/babel__core@^7.0.0":
   version "7.1.9"
@@ -903,25 +977,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/cheerio@*":
-  version "0.22.16"
-  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.16.tgz#c748a97b8a6f781b04bbda4a552e11b35bcc77e4"
-  integrity sha512-bSbnU/D4yzFdzLpp3+rcDj0aQQMIRUBNJU7azPxdqMpnexjUSvGJyDuOBQBHeOZh1mMKgsJm6Dy+LLh80Ew4tQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
-
-"@types/enzyme@^3.10.5":
-  version "3.10.5"
-  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.5.tgz#fe7eeba3550369eed20e7fb565bfb74eec44f1f0"
-  integrity sha512-R+phe509UuUYy9Tk0YlSbipRpfVtIzb/9BHn5pTEtjJTF5LXvUjrIQcZvNyANNEyFrd2YGs196PniNT1fgvOQA==
-  dependencies:
-    "@types/cheerio" "*"
-    "@types/react" "*"
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
@@ -980,6 +1039,14 @@
   integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@*":
+  version "26.0.19"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.19.tgz#e6fa1e3def5842ec85045bd5210e9bb8289de790"
+  integrity sha512-jqHoirTG61fee6v6rwbnEuKhpSKih0tuhqeFbCmMmErhtu3BYlOZaXWjffgOstMM4S/3iQD31lI5bGLTrs97yQ==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
 
 "@types/jest@26.x", "@types/jest@^26.0.9":
   version "26.0.9"
@@ -1071,6 +1138,13 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
   integrity sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.5"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz#5bf25c91ad2d7b38f264b12275e5c92a66d849b0"
+  integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/uglify-js@*":
   version "3.0.5"
@@ -1427,21 +1501,6 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-airbnb-prop-types@^2.16.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz#b96274cefa1abb14f623f804173ee97c13971dc2"
-  integrity sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==
-  dependencies:
-    array.prototype.find "^2.1.1"
-    function.prototype.name "^1.1.2"
-    is-regex "^1.1.0"
-    object-is "^1.1.2"
-    object.assign "^4.1.0"
-    object.entries "^1.1.2"
-    prop-types "^15.7.2"
-    prop-types-exact "^1.2.0"
-    react-is "^16.13.1"
-
 ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
@@ -1597,6 +1656,14 @@ argv@0.0.2:
   resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
   integrity sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=
 
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -1611,11 +1678,6 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
-
-array-filter@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-1.0.0.tgz#baf79e62e6ef4c2a4c0b831232daffec251f9d83"
-  integrity sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=
 
 array-find-index@^1.0.1:
   version "1.0.2"
@@ -1667,22 +1729,6 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
-
-array.prototype.find@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.1.1.tgz#3baca26108ca7affb08db06bf0be6cb3115a969c"
-  integrity sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.4"
-
-array.prototype.flat@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
-  integrity sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
 
 array.prototype.flatmap@^1.2.3:
   version "1.2.3"
@@ -2290,7 +2336,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@4.1.0:
+chalk@4.1.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -2327,18 +2373,6 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
-
-cheerio@^1.0.0-rc.3:
-  version "1.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
-  integrity sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==
-  dependencies:
-    css-select "~1.2.0"
-    dom-serializer "~0.1.1"
-    entities "~1.1.1"
-    htmlparser2 "^3.9.1"
-    lodash "^4.15.0"
-    parse5 "^3.0.1"
 
 chokidar@^2.1.8:
   version "2.1.8"
@@ -2610,7 +2644,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.18.0, commander@^2.19.0, commander@^2.20.0, commander@~2.20.3:
+commander@^2.18.0, commander@^2.20.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2823,6 +2857,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+core-js-pure@^3.0.0:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.8.1.tgz#23f84048f366fdfcf52d3fd1c68fec349177d119"
+  integrity sha512-Se+LaxqXlVXGvmexKGPvnUIYC1jwXu1H6Pkyb3uBM5d8/NELMYCHs/4/roD7721NxrTLyv7e5nXd5/QLBO+10g==
+
 core-js@^3.6.1:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
@@ -2954,7 +2993,7 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
-css-select@^1.1.0, css-select@~1.2.0:
+css-select@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
   integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
@@ -2968,6 +3007,20 @@ css-what@2.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -3265,6 +3318,11 @@ diff-sequences@^26.3.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.3.0.tgz#62a59b1b29ab7fd27cef2a33ae52abe73042d0a2"
   integrity sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==
 
+diff-sequences@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
+  integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -3280,11 +3338,6 @@ dir-glob@^3.0.0, dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
-
-discontinuous-range@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
-  integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
 
 dns-equal@^1.0.0:
   version "1.0.0"
@@ -3320,6 +3373,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-accessibility-api@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
+
 dom-converter@^0.2:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
@@ -3335,14 +3393,6 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
-dom-serializer@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
-  integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
-  dependencies:
-    domelementtype "^1.3.0"
-    entities "^1.1.1"
-
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
@@ -3353,7 +3403,7 @@ domain-browser@^1.1.1:
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
-domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
+domelementtype@1, domelementtype@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
@@ -3551,7 +3601,7 @@ enquirer@^2.3.5:
   dependencies:
     ansi-colors "^3.2.1"
 
-entities@^1.1.1, entities@~1.1.1:
+entities@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
@@ -3574,77 +3624,6 @@ env-paths@^2.2.0:
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
   integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
 
-enzyme-adapter-react-16@^1.15.3:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.3.tgz#90154055be3318d70a51df61ac89cfa22e3d5f60"
-  integrity sha512-98rqNI4n9HZslWIPuuwy4hK1bxRuMy+XX0CU1dS8iUqcgisTxeBaap6oPp2r4MWC8OphCbbqAT8EU/xHz3zIaQ==
-  dependencies:
-    enzyme-adapter-utils "^1.13.1"
-    enzyme-shallow-equal "^1.0.4"
-    has "^1.0.3"
-    object.assign "^4.1.0"
-    object.values "^1.1.1"
-    prop-types "^15.7.2"
-    react-is "^16.13.1"
-    react-test-renderer "^16.0.0-0"
-    semver "^5.7.0"
-
-enzyme-adapter-utils@^1.13.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.13.1.tgz#59c1b734b0927543e3d8dc477299ec957feb312d"
-  integrity sha512-5A9MXXgmh/Tkvee3bL/9RCAAgleHqFnsurTYCbymecO4ohvtNO5zqIhHxV370t7nJAwaCfkgtffarKpC0GPt0g==
-  dependencies:
-    airbnb-prop-types "^2.16.0"
-    function.prototype.name "^1.1.2"
-    object.assign "^4.1.0"
-    object.fromentries "^2.0.2"
-    prop-types "^15.7.2"
-    semver "^5.7.1"
-
-enzyme-shallow-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.1.tgz#7afe03db3801c9b76de8440694096412a8d9d49e"
-  integrity sha512-hGA3i1so8OrYOZSM9whlkNmVHOicJpsjgTzC+wn2JMJXhq1oO4kA4bJ5MsfzSIcC71aLDKzJ6gZpIxrqt3QTAQ==
-  dependencies:
-    has "^1.0.3"
-    object-is "^1.0.2"
-
-enzyme-shallow-equal@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.4.tgz#b9256cb25a5f430f9bfe073a84808c1d74fced2e"
-  integrity sha512-MttIwB8kKxypwHvRynuC3ahyNc+cFbR8mjVIltnmzQ0uKGqmsfO4bfBuLxb0beLNPhjblUEYvEbsg+VSygvF1Q==
-  dependencies:
-    has "^1.0.3"
-    object-is "^1.1.2"
-
-enzyme@^3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.11.0.tgz#71d680c580fe9349f6f5ac6c775bc3e6b7a79c28"
-  integrity sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==
-  dependencies:
-    array.prototype.flat "^1.2.3"
-    cheerio "^1.0.0-rc.3"
-    enzyme-shallow-equal "^1.0.1"
-    function.prototype.name "^1.1.2"
-    has "^1.0.3"
-    html-element-map "^1.2.0"
-    is-boolean-object "^1.0.1"
-    is-callable "^1.1.5"
-    is-number-object "^1.0.4"
-    is-regex "^1.0.5"
-    is-string "^1.0.5"
-    is-subset "^0.1.1"
-    lodash.escape "^4.0.1"
-    lodash.isequal "^4.5.0"
-    object-inspect "^1.7.0"
-    object-is "^1.0.2"
-    object.assign "^4.1.0"
-    object.entries "^1.1.1"
-    object.values "^1.1.1"
-    raf "^3.4.1"
-    rst-selector-parser "^2.2.3"
-    string.prototype.trim "^1.2.1"
-
 err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
@@ -3664,7 +3643,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.4:
+es-abstract@^1.17.0, es-abstract@^1.17.0-next.1:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
   integrity sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
@@ -4498,24 +4477,10 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-function.prototype.name@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.2.tgz#5cdf79d7c05db401591dfde83e3b70c5123e9a45"
-  integrity sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    functions-have-names "^1.2.0"
-
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
-
-functions-have-names@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.1.tgz#a981ac397fa0c9964551402cdc5533d7a4d52f91"
-  integrity sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA==
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -4960,13 +4925,6 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
-html-element-map@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/html-element-map/-/html-element-map-1.2.0.tgz#dfbb09efe882806af63d990cf6db37993f099f22"
-  integrity sha512-0uXq8HsuG1v2TmQ8QkIhzbrqeskE4kn52Q18QJ9iAA/SnHoEKXWiUxHQtclRsCFWEUD2So34X+0+pZZu862nnw==
-  dependencies:
-    array-filter "^1.0.0"
-
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
@@ -5012,7 +4970,7 @@ html-webpack-plugin@^4.3.0:
     tapable "^1.1.3"
     util.promisify "1.0.0"
 
-htmlparser2@^3.3.0, htmlparser2@^3.9.1:
+htmlparser2@^3.3.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
@@ -5423,11 +5381,6 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-boolean-object@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.1.tgz#10edc0900dd127697a92f6f9807c7617d68ac48e"
-  integrity sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ==
-
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -5567,11 +5520,6 @@ is-npm@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
   integrity sha1-8vtjpl5JBbQGyGBydloaTceTufQ=
 
-is-number-object@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.4.tgz#36ac95e741cf18b283fc1ddf5e83da798e3ec197"
-  integrity sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==
-
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -5682,11 +5630,6 @@ is-string@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
   integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
-
-is-subset@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
-  integrity sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=
 
 is-symbol@^1.0.2:
   version "1.0.3"
@@ -5890,6 +5833,16 @@ jest-diff@^25.2.1:
     diff-sequences "^25.2.6"
     jest-get-type "^25.2.6"
     pretty-format "^25.3.0"
+
+jest-diff@^26.0.0:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
+  integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.6.2"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.2"
 
 jest-diff@^26.4.0:
   version "26.4.0"
@@ -6729,25 +6682,10 @@ lodash.clonedeep@^4.5.0, lodash.clonedeep@~4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.escape@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
-  integrity sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=
-
 lodash.escaperegexp@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
   integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
-
-lodash.flattendeep@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
-  integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
-
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"
@@ -6814,7 +6752,7 @@ lodash.without@~4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5:
+lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -6897,6 +6835,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 macos-release@^2.2.0:
   version "2.3.0"
@@ -7167,6 +7110,11 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -7275,11 +7223,6 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moo@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
-  integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -7351,17 +7294,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
-
-nearley@^2.7.10:
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.19.1.tgz#4af4006e16645ff800e9f993c3af039857d9dbdc"
-  integrity sha512-xq47GIUGXxU9vQg7g/y1o1xuKnkO7ev4nRWqftmQrLkfnE/FjRqDaGOUakM8XHPn/6pW3bGjU2wgoJyId90rqg==
-  dependencies:
-    commander "^2.19.0"
-    moo "^0.5.0"
-    railroad-diagrams "^1.0.0"
-    randexp "0.4.6"
-    semver "^5.4.1"
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -7827,18 +7759,10 @@ object-inspect@^1.7.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
   integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
 
-object-is@^1.0.1, object-is@^1.0.2:
+object-is@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.2.tgz#6b80eb84fe451498f65007982f035a5b445edec4"
   integrity sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==
-
-object-is@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.2.tgz#c5d2e87ff9e119f78b7a088441519e2eec1573b6"
-  integrity sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
 
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -7861,16 +7785,6 @@ object.assign@^4.1.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
-
-object.entries@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.1.tgz#ee1cf04153de02bb093fec33683900f57ce5399b"
-  integrity sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
-    has "^1.0.3"
 
 object.entries@^1.1.2:
   version "1.1.2"
@@ -8283,13 +8197,6 @@ parse5@5.1.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
 
-parse5@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
-  integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
-  dependencies:
-    "@types/node" "*"
-
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -8520,6 +8427,16 @@ pretty-format@^25.2.1, pretty-format@^25.3.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty-format@^26.0.0, pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 pretty-format@^26.4.0:
   version "26.4.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.0.tgz#c08073f531429e9e5024049446f42ecc9f933a3b"
@@ -8572,15 +8489,6 @@ promzard@^0.3.0:
   integrity sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=
   dependencies:
     read "1"
-
-prop-types-exact@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/prop-types-exact/-/prop-types-exact-1.2.0.tgz#825d6be46094663848237e3925a98c6e944e9869"
-  integrity sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==
-  dependencies:
-    has "^1.0.3"
-    object.assign "^4.1.0"
-    reflect.ownkeys "^0.2.0"
 
 prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
@@ -8740,26 +8648,6 @@ qw@~1.0.1:
   resolved "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz#efbfdc740f9ad054304426acb183412cc8b996d4"
   integrity sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=
 
-raf@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
-  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
-  dependencies:
-    performance-now "^2.1.0"
-
-railroad-diagrams@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
-  integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
-
-randexp@0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
-  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
-  dependencies:
-    discontinuous-range "1.0.0"
-    ret "~0.1.10"
-
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -8824,30 +8712,20 @@ react-hot-loader@^4.12.21:
     shallowequal "^1.1.0"
     source-map "^0.7.3"
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
+react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
   integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
-react-is@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
-react-test-renderer@^16.0.0-0:
-  version "16.13.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.0.tgz#39ba3bf72cedc8210c3f81983f0bb061b14a3014"
-  integrity sha512-NQ2S9gdMUa7rgPGpKGyMcwl1d6D9MCF0lftdI3kts6kkiX+qvpC955jNjAZXlIDTjnN9jwFI8A8XhRh/9v0spA==
-  dependencies:
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    react-is "^16.8.6"
-    scheduler "^0.19.0"
 
 react@^16.13.1:
   version "16.13.1"
@@ -9026,17 +8904,20 @@ redent@^2.0.0:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
 
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
+
 redeyed@~2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-2.1.1.tgz#8984b5815d99cb220469c99eeeffe38913e6cc0b"
   integrity sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=
   dependencies:
     esprima "~4.0.0"
-
-reflect.ownkeys@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
-  integrity sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=
 
 regenerator-runtime@0.13.5:
   version "0.13.5"
@@ -9309,14 +9190,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rst-selector-parser@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
-  integrity sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=
-  dependencies:
-    lodash.flattendeep "^4.4.0"
-    nearley "^2.7.10"
-
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -9384,14 +9257,6 @@ saxes@^5.0.0:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
-
-scheduler@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.0.tgz#a715d56302de403df742f4a9be11975b32f5698d"
-  integrity sha512-xowbVaTPe9r7y7RUejcK73/j8tt2jfiyTednOvHbA8JoClvMYCp+r8QegLwK/n8zWQAtZb1fFnER4XLBZXrCxA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.19.1:
   version "0.19.1"
@@ -9489,7 +9354,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -9813,6 +9678,14 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
+
 source-map-support@^0.5.3, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
@@ -10105,15 +9978,6 @@ string.prototype.matchall@^4.0.2:
     regexp.prototype.flags "^1.3.0"
     side-channel "^1.0.2"
 
-string.prototype.trim@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz#141233dff32c82bfad80684d7e5f0869ee0fb782"
-  integrity sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
-
 string.prototype.trimend@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
@@ -10231,6 +10095,13 @@ strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Switch to using `react-testing-library` instead of `enzyme`.

This is an improvement in the way the tests are written and simulates user typing events better, and has already caught a few bugs.