### PR TITLE
fix: default value with decimal scale renders correctly part 2

### DIFF
--- a/src/components/__tests__/CurrencyInput.spec.tsx
+++ b/src/components/__tests__/CurrencyInput.spec.tsx
@@ -66,6 +66,16 @@ describe('<CurrencyInput/>', () => {
     expect(screen.getByRole('textbox')).toHaveValue('£0.00');
   });
 
+  it('Renders with value 0.1 with decimalScale 2', () => {
+    render(<CurrencyInput value={0.1} prefix="£" decimalScale={2} />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('£0.10');
+
+    userEvent.type(screen.getByRole('textbox'), '{backspace}');
+
+    expect(screen.getByRole('textbox')).toHaveValue('£0.1');
+  });
+
   it('should go to end of string on focus', () => {
     render(<CurrencyInput defaultValue={123} />);
     userEvent.type(screen.getByRole('textbox'), '{arrowleft}4{arrowright}6');

--- a/src/components/utils/__tests__/formatValue.spec.ts
+++ b/src/components/utils/__tests__/formatValue.spec.ts
@@ -151,6 +151,30 @@ describe('formatValue', () => {
     ).toEqual('£0.00');
   });
 
+  it('should handle decimal values with decimalScale', () => {
+    expect(
+      formatValue({
+        decimalSeparator: '.',
+        groupSeparator: ',',
+        disableGroupSeparators: false,
+        decimalScale: 2,
+        prefix: '£',
+        value: '0.1',
+      })
+    ).toEqual('£0.10');
+
+    expect(
+      formatValue({
+        decimalSeparator: '.',
+        groupSeparator: ',',
+        disableGroupSeparators: false,
+        decimalScale: 4,
+        prefix: '£',
+        value: '0.01',
+      })
+    ).toEqual('£0.0100');
+  });
+
   describe('negative values', () => {
     it('should handle negative values', () => {
       expect(

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -98,10 +98,10 @@ export const formatValue = (options: FormatValueOptions): string => {
   // Include decimal separator if user input ends with decimal separator
   const includeDecimalSeparator = _value.slice(-1) === decimalSeparator ? decimalSeparator : '';
 
-  // Keep original decimal padding
+  // Keep original decimal padding if no decimalScale
   const [, decimals] = value.match(RegExp('\\d+\\.(\\d+)')) || [];
 
-  if (decimals && decimalSeparator) {
+  if (!decimalScale && decimals && decimalSeparator) {
     if (formatted.includes(decimalSeparator)) {
       formatted = formatted.replace(
         RegExp(`(\\d+)(${escapeRegExp(decimalSeparator)})(\\d+)`, 'g'),


### PR DESCRIPTION
Fixes initial rendering if value has decimals and decimal scale eg. `<CurrencyInput value={0.1} decimalScale={2} />`