### PR TITLE
fix: intl config currency is optional

### DIFF
--- a/src/components/CurrencyInputProps.ts
+++ b/src/components/CurrencyInputProps.ts
@@ -4,7 +4,7 @@ type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
 
 export type IntlConfig = {
   locale: string;
-  currency: string;
+  currency?: string;
 };
 
 export type CurrencyInputProps = Overwrite<

--- a/src/components/utils/__tests__/formatValue.spec.ts
+++ b/src/components/utils/__tests__/formatValue.spec.ts
@@ -272,6 +272,22 @@ describe('formatValue', () => {
       ).toEqual('¥123,456.79');
     });
 
+    it('should able to omit intlConfig.currency', () => {
+      expect(
+        formatValue({
+          value: '-500000',
+          intlConfig: { locale: 'en-IN' },
+        })
+      ).toEqual('-5,00,000');
+
+      expect(
+        formatValue({
+          value: '123456.79',
+          intlConfig: { locale: 'zh-CN' },
+        })
+      ).toEqual('123,456.79');
+    });
+
     it('should handle suffix', () => {
       expect(
         formatValue({

--- a/src/components/utils/__tests__/getLocaleConfig.spec.ts
+++ b/src/components/utils/__tests__/getLocaleConfig.spec.ts
@@ -16,4 +16,12 @@ describe('getLocaleConfig', () => {
       groupSeparator: ',',
     });
   });
+
+  it('should return locale config from intlConfig even without currency', () => {
+    expect(getLocaleConfig({ locale: 'fr-FR' })).toStrictEqual({
+      currencySymbol: '',
+      decimalSeparator: ',',
+      groupSeparator: ' ',
+    });
+  });
 });

--- a/src/components/utils/cleanValue.ts
+++ b/src/components/utils/cleanValue.ts
@@ -2,17 +2,18 @@ import { parseAbbrValue } from './parseAbbrValue';
 import { removeSeparators } from './removeSeparators';
 import { removeInvalidChars } from './removeInvalidChars';
 import { escapeRegExp } from './escapeRegExp';
+import { CurrencyInputProps } from '../CurrencyInputProps';
 
-export type CleanValueOptions = {
-  value: string;
-  decimalSeparator?: string;
-  groupSeparator?: string;
-  allowDecimals?: boolean;
-  decimalsLimit?: number;
-  allowNegativeValue?: boolean;
-  disableAbbreviations?: boolean;
-  prefix?: string;
-};
+export type CleanValueOptions = Pick<
+  CurrencyInputProps,
+  | 'decimalSeparator'
+  | 'groupSeparator'
+  | 'allowDecimals'
+  | 'decimalsLimit'
+  | 'allowNegativeValue'
+  | 'disableAbbreviations'
+  | 'prefix'
+> & { value: string };
 
 /**
  * Remove prefix, separators and extra decimals from value

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -84,12 +84,17 @@ export const formatValue = (options: FormatValueOptions): string => {
       : _value;
 
   const numberFormatter = intlConfig
-    ? new Intl.NumberFormat(intlConfig.locale, {
-        style: 'currency',
-        currency: intlConfig.currency,
-        minimumFractionDigits: decimalScale || 0,
-        maximumFractionDigits: 20,
-      })
+    ? new Intl.NumberFormat(
+        intlConfig.locale,
+        intlConfig.currency
+          ? {
+              style: 'currency',
+              currency: intlConfig.currency,
+              minimumFractionDigits: decimalScale || 0,
+              maximumFractionDigits: 20,
+            }
+          : undefined
+      )
     : new Intl.NumberFormat(undefined, {
         minimumFractionDigits: decimalScale || 0,
         maximumFractionDigits: 20,

--- a/src/components/utils/getLocaleConfig.ts
+++ b/src/components/utils/getLocaleConfig.ts
@@ -17,10 +17,9 @@ const defaultConfig: LocaleConfig = {
  */
 export const getLocaleConfig = (intlConfig?: IntlConfig): LocaleConfig => {
   const { locale, currency } = intlConfig || {};
-  const numberFormatter =
-    locale && currency
-      ? new Intl.NumberFormat(locale, { currency, style: 'currency' })
-      : new Intl.NumberFormat();
+  const numberFormatter = locale
+    ? new Intl.NumberFormat(locale, currency ? { currency, style: 'currency' } : undefined)
+    : new Intl.NumberFormat();
 
   return numberFormatter.formatToParts(1000.1).reduce((prev, curr): LocaleConfig => {
     if (curr.type === 'currency') {


### PR DESCRIPTION
`intlConfig` option `currency` can be optional, so formatting can still happen without currency symbol.

Issue: #129 