### PR TITLE
fix: prevent cursor moving if only negative value at start

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -224,7 +224,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
         key,
         currentTarget: { selectionStart },
       } = event;
-      if (key !== 'ArrowUp' && key !== 'ArrowDown') {
+      if (key !== 'ArrowUp' && key !== 'ArrowDown' && stateValue !== '-') {
         const suffix = getSuffix(stateValue, { groupSeparator, decimalSeparator });
 
         if (suffix && selectionStart && selectionStart > stateValue.length - suffix.length) {
@@ -241,7 +241,13 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
     /* istanbul ignore next */
     useEffect(() => {
       // prevent cursor jumping if editing value
-      if (dirty && inputRef && typeof inputRef === 'object' && inputRef.current) {
+      if (
+        dirty &&
+        stateValue !== '-' &&
+        inputRef &&
+        typeof inputRef === 'object' &&
+        inputRef.current
+      ) {
         inputRef.current.setSelectionRange(cursor, cursor);
       }
     }, [cursor, inputRef, dirty]);


### PR DESCRIPTION
Prevent cursor moving if only "-" value, and prevents accidentally entering "1-" at the beginning, which parses to "1" (incorrect).

Issue: #131 