### PR TITLE
fix: remove prefix if letters

### DIFF
--- a/src/components/utils/__tests__/cleanValue.spec.ts
+++ b/src/components/utils/__tests__/cleanValue.spec.ts
@@ -33,6 +33,27 @@ describe('cleanValue', () => {
         prefix: '$',
       })
     ).toEqual('5.5');
+
+    expect(
+      cleanValue({
+        value: '$ 1.5',
+        prefix: '$ ',
+      })
+    ).toEqual('1.5');
+
+    expect(
+      cleanValue({
+        value: 'JMD5.5',
+        prefix: 'JMD',
+      })
+    ).toEqual('5.5');
+
+    expect(
+      cleanValue({
+        value: 'Value: 1.5',
+        prefix: 'Value: ',
+      })
+    ).toEqual('1.5');
   });
 
   it('should remove suffix', () => {

--- a/src/components/utils/cleanValue.ts
+++ b/src/components/utils/cleanValue.ts
@@ -35,8 +35,13 @@ export const cleanValue = ({
   const abbreviations = disableAbbreviations ? [] : ['k', 'm', 'b'];
   const isNegative = new RegExp(`^\\d?-${prefix ? `${escapeRegExp(prefix)}?` : ''}\\d`).test(value);
 
+  // Is there a digit before the prefix? eg. 1$
   const [prefixWithValue, preValue] = RegExp(`(\\d+)-?${escapeRegExp(prefix)}`).exec(value) || [];
-  const withoutPrefix = prefix ? value.replace(prefixWithValue, '').concat(preValue) : value;
+  const withoutPrefix = prefix
+    ? prefixWithValue
+      ? value.replace(prefixWithValue, '').concat(preValue)
+      : value.replace(prefix, '')
+    : value;
   const withoutSeparators = removeSeparators(withoutPrefix, groupSeparator);
   const withoutInvalidChars = removeInvalidChars(withoutSeparators, [
     groupSeparator,


### PR DESCRIPTION
Removes prefix correctly if prefix is letters only.

Issue: #136 