### PR TITLE
fix: handle intl config with prefix and negative

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -72,8 +72,8 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       groupSeparator,
       disableGroupSeparators,
       intlConfig,
-      prefix,
-      suffix,
+      prefix: prefix || localeConfig.prefix,
+      suffix: suffix,
     };
 
     const cleanValueOptions: Partial<CleanValueOptions> = {
@@ -83,7 +83,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       decimalsLimit: decimalsLimit || fixedDecimalLength || 2,
       allowNegativeValue,
       disableAbbreviations,
-      prefix,
+      prefix: prefix || localeConfig.prefix,
     };
 
     const formattedStateValue =

--- a/src/components/__tests__/CurrencyInput-intl-config.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-intl-config.spec.tsx
@@ -107,5 +107,21 @@ describe('<CurrencyInput/> intlConfig', () => {
 
       expect(screen.getByRole('textbox')).toHaveValue('₹12,34,567');
     });
+
+    it('should handle onValueChange with negative value and prefix', () => {
+      render(
+        <CurrencyInput
+          id={id}
+          intlConfig={{ locale: 'nl-NL', currency: 'EUR' }}
+          onValueChange={onValueChangeSpy}
+        />
+      );
+
+      expect(screen.getByRole('textbox')).toHaveValue('');
+
+      userEvent.type(screen.getByRole('textbox'), '-1200');
+
+      expect(screen.getByRole('textbox')).toHaveValue('€\xa0-1.200');
+    });
   });
 });

--- a/src/components/utils/__tests__/cleanValue.spec.ts
+++ b/src/components/utils/__tests__/cleanValue.spec.ts
@@ -123,6 +123,15 @@ describe('cleanValue', () => {
       ).toEqual('-1000');
     });
 
+    it('should handle negative value with intl with prefix', () => {
+      expect(
+        cleanValue({
+          value: '€\xa0-123',
+          prefix: '€',
+        })
+      ).toEqual('-123');
+    });
+
     it('should handle negative value with decimal', () => {
       expect(
         cleanValue({

--- a/src/components/utils/__tests__/formatValue.spec.ts
+++ b/src/components/utils/__tests__/formatValue.spec.ts
@@ -270,6 +270,21 @@ describe('formatValue', () => {
           intlConfig: { locale: 'zh-CN', currency: 'CNY' },
         })
       ).toEqual('¥123,456.79');
+
+      expect(
+        formatValue({
+          value: '-123',
+          intlConfig: { locale: 'nl-NL', currency: 'EUR' },
+        })
+      ).toEqual('€\xa0-123');
+
+      expect(
+        formatValue({
+          value: '-123',
+          intlConfig: { locale: 'nl-NL', currency: 'EUR' },
+          prefix: '€',
+        })
+      ).toEqual('€\xa0-123');
     });
 
     it('should able to omit intlConfig.currency', () => {
@@ -334,6 +349,22 @@ describe('formatValue', () => {
           prefix: '₹',
         })
       ).toEqual('₹345');
+
+      expect(
+        formatValue({
+          value: '123',
+          intlConfig: { locale: 'en-US', currency: 'USD' },
+          prefix: '$',
+        })
+      ).toEqual('$123');
+
+      expect(
+        formatValue({
+          value: '-123',
+          intlConfig: { locale: 'en-US', currency: 'USD' },
+          prefix: '$',
+        })
+      ).toEqual('-$123');
     });
 
     it('should override locale if groupSeparator passed in', () => {
@@ -452,6 +483,15 @@ describe('formatValue', () => {
           intlConfig: { locale: 'de-DE', currency: 'EUR' },
         })
       ).toEqual(`123.98$`);
+
+      expect(
+        formatValue({
+          value: '-123.98',
+          decimalSeparator: '.',
+          suffix: '$',
+          intlConfig: { locale: 'de-DE', currency: 'EUR' },
+        })
+      ).toEqual(`-123.98$`);
     });
 
     it('should handle custom suffix and prefix', () => {

--- a/src/components/utils/__tests__/getLocaleConfig.spec.ts
+++ b/src/components/utils/__tests__/getLocaleConfig.spec.ts
@@ -6,6 +6,8 @@ describe('getLocaleConfig', () => {
       currencySymbol: '',
       decimalSeparator: '.',
       groupSeparator: ',',
+      prefix: '',
+      suffix: '',
     });
   });
 
@@ -14,6 +16,8 @@ describe('getLocaleConfig', () => {
       currencySymbol: '￥',
       decimalSeparator: '',
       groupSeparator: ',',
+      prefix: '￥',
+      suffix: '',
     });
   });
 
@@ -22,6 +26,8 @@ describe('getLocaleConfig', () => {
       currencySymbol: '',
       decimalSeparator: ',',
       groupSeparator: ' ',
+      prefix: '',
+      suffix: '',
     });
   });
 });

--- a/src/components/utils/cleanValue.ts
+++ b/src/components/utils/cleanValue.ts
@@ -33,7 +33,8 @@ export const cleanValue = ({
   }
 
   const abbreviations = disableAbbreviations ? [] : ['k', 'm', 'b'];
-  const isNegative = new RegExp(`^\\d?-${prefix ? `${escapeRegExp(prefix)}?` : ''}\\d`).test(value);
+  const reg = new RegExp(`((^|\\D)-\\d)|(-${escapeRegExp(prefix)})`);
+  const isNegative = reg.test(value);
 
   // Is there a digit before the prefix? eg. 1$
   const [prefixWithValue, preValue] = RegExp(`(\\d+)-?${escapeRegExp(prefix)}`).exec(value) || [];

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -177,8 +177,20 @@ const replaceParts = (
   return parts
     .reduce(
       (prev, { type, value }, i) => {
-        if (type === 'currency' && prefix) {
-          return [...prev, prefix];
+        if (i === 0 && prefix) {
+          if (type === 'minusSign') {
+            return [value, prefix];
+          }
+
+          if (type === 'currency') {
+            return [...prev, prefix];
+          }
+
+          return [prefix, value];
+        }
+
+        if (type === 'currency') {
+          return prefix ? prev : [...prev, value];
         }
 
         if (type === 'group') {
@@ -197,14 +209,6 @@ const replaceParts = (
 
         if (type === 'fraction') {
           return [...prev, decimalScale !== undefined ? value.slice(0, decimalScale) : value];
-        }
-
-        if (type === 'minusSign' && prefix) {
-          return [value, prefix];
-        }
-
-        if (prefix && i === 0) {
-          return [prefix, value];
         }
 
         return [...prev, value];

--- a/src/components/utils/getLocaleConfig.ts
+++ b/src/components/utils/getLocaleConfig.ts
@@ -4,12 +4,16 @@ type LocaleConfig = {
   currencySymbol: string;
   groupSeparator: string;
   decimalSeparator: string;
+  prefix: string;
+  suffix: string;
 };
 
 const defaultConfig: LocaleConfig = {
   currencySymbol: '',
   groupSeparator: '',
   decimalSeparator: '',
+  prefix: '',
+  suffix: '',
 };
 
 /**
@@ -21,9 +25,13 @@ export const getLocaleConfig = (intlConfig?: IntlConfig): LocaleConfig => {
     ? new Intl.NumberFormat(locale, currency ? { currency, style: 'currency' } : undefined)
     : new Intl.NumberFormat();
 
-  return numberFormatter.formatToParts(1000.1).reduce((prev, curr): LocaleConfig => {
+  return numberFormatter.formatToParts(1000.1).reduce((prev, curr, i): LocaleConfig => {
     if (curr.type === 'currency') {
-      return { ...prev, currencySymbol: curr.value };
+      if (i === 0) {
+        return { ...prev, currencySymbol: curr.value, prefix: curr.value };
+      } else {
+        return { ...prev, currencySymbol: curr.value, suffix: curr.value };
+      }
     }
     if (curr.type === 'group') {
       return { ...prev, groupSeparator: curr.value };

--- a/src/examples/Example1.tsx
+++ b/src/examples/Example1.tsx
@@ -14,7 +14,6 @@ export const Example1: FC = () => {
    * Handle validation
    */
   const handleOnValueChange = (value: string | undefined): void => {
-    console.log(' >> value: ', value);
     setRawValue(value === undefined ? 'undefined' : value || ' ');
 
     if (!value) {
@@ -65,7 +64,7 @@ export const Example1: FC = () => {
                 placeholder="Please enter a number"
                 prefix={prefix}
                 step={1}
-                decimalScale={5}
+                decimalScale={2}
               />
               <div className="invalid-feedback">{errorMessage}</div>
             </div>


### PR DESCRIPTION
Fix bug when intl config specifies a prefix and user enters a negative value.

Issue: #146 