### PR TITLE
Fix/various issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
     - [Prefix and Suffix](#prefix-and-suffix)
     - [Separators](#separators)
     - [Intl Locale Config](#intl-locale-config)
+    - [Decimal Scale and Decimals Limit](#decimal-scale-and-decimals-limit)
     - [Fixed Decimal Length](#fixed-decimal-length)
-  - [Decimal Scale and Decimals Limit](#decimal-scale-and-decimals-limit)
   - [Format values for display](#format-values-for-display)
   - [v3.0.0 Release Notes](#v300-release-notes)
     - [Breaking Changes](#breaking-changes)
@@ -72,27 +72,27 @@ Have a look in [`src/examples`](https://github.com/cchanxzy/react-currency-input
 
 ## Props
 
-| Name                   | Type       | Default        | Description                                                                                    |
-| ---------------------- | ---------- | -------------- | ---------------------------------------------------------------------------------------------- |
-| allowDecimals          | `boolean`  | `true`         | Allow decimals                                                                                 |
-| allowNegativeValue     | `boolean`  | `true`         | Allow user to enter negative value                                                             |
-| defaultValue           | `number`   |                | Default value                                                                                  |
-| value                  | `number`   |                | Programmatically set the value                                                                 |
-| onValueChange          | `function` |                | Handle change in value                                                                         |
-| placeholder            | `string`   |                | Placeholder if no value                                                                        |
-| decimalsLimit          | `number`   | `2`            | Limit length of decimals allowed                                                               |
-| decimalScale           | `number`   |                | Specify decimal scale for padding/trimming eg. 1.5 -> 1.50 or 1.234 -> 1.23 if decimal scale 2 |
-| fixedDecimalLength     | `number`   |                | Value will always have the specified length of decimals                                        |
-| prefix                 | `string`   |                | Include a prefix eg. £ or \$                                                                   |
-| suffix                 | `string`   |                | Include a suffix eg. € or %                                                                    |
-| decimalSeparator       | `string`   | locale default | Separator between integer part and fractional part of value                                    |
-| groupSeparator         | `string`   | locale default | Separator between thousand, million and billion                                                |
-| intlConfig             | `object`   |                | International locale config                                                                    |
-| disabled               | `boolean`  | `false`        | Disabled                                                                                       |
-| disableAbbreviations   | `boolean`  | `false`        | Disable abbreviations eg. 1k -> 1,000, 2m -> 2,000,000                                         |
-| disableGroupSeparators | `boolean`  | `false`        | Disable auto adding the group separator between values, eg. 1000 -> 1,000                      |
-| maxLength              | `number`   |                | Maximum characters the user can enter                                                          |
-| step                   | `number`   |                | Incremental value change on arrow down and arrow up key press                                  |
+| Name                                               | Type       | Default        | Description                                                                                    |
+| -------------------------------------------------- | ---------- | -------------- | ---------------------------------------------------------------------------------------------- |
+| allowDecimals                                      | `boolean`  | `true`         | Allow decimals                                                                                 |
+| allowNegativeValue                                 | `boolean`  | `true`         | Allow user to enter negative value                                                             |
+| defaultValue                                       | `number`   |                | Default value                                                                                  |
+| value                                              | `number`   |                | Programmatically set the value                                                                 |
+| onValueChange                                      | `function` |                | Handle change in value                                                                         |
+| placeholder                                        | `string`   |                | Placeholder if no value                                                                        |
+| [decimalsLimit](#decimal-scale-and-decimals-limit) | `number`   | `2`            | Limit length of decimals allowed                                                               |
+| [decimalScale](#decimal-scale-and-decimals-limit)  | `number`   |                | Specify decimal scale for padding/trimming eg. 1.5 -> 1.50 or 1.234 -> 1.23 if decimal scale 2 |
+| [fixedDecimalLength](#fixed-decimal-length)        | `number`   |                | Value will always have the specified length of decimals                                        |
+| [prefix](#prefix-and-suffix)                       | `string`   |                | Include a prefix eg. £ or \$                                                                   |
+| [suffix](#prefix-and-suffix)                       | `string`   |                | Include a suffix eg. € or %                                                                    |
+| [decimalSeparator](#separators)                    | `string`   | locale default | Separator between integer part and fractional part of value                                    |
+| [groupSeparator](#separators)                      | `string`   | locale default | Separator between thousand, million and billion                                                |
+| [intlConfig](#intl-locale-config)                  | `object`   |                | International locale config                                                                    |
+| disabled                                           | `boolean`  | `false`        | Disabled                                                                                       |
+| disableAbbreviations                               | `boolean`  | `false`        | Disable abbreviations eg. 1k -> 1,000, 2m -> 2,000,000                                         |
+| [disableGroupSeparators](#separators)              | `boolean`  | `false`        | Disable auto adding the group separator between values, eg. 1000 -> 1,000                      |
+| maxLength                                          | `number`   |                | Maximum characters the user can enter                                                          |
+| step                                               | `number`   |                | Incremental value change on arrow down and arrow up key press                                  |
 
 ### Abbreviations
 
@@ -160,6 +160,28 @@ import CurrencyInput from 'react-currency-input-field';
 
 Any prefix, suffix, group separator and decimal separator options passed in will override the default locale settings.
 
+### Decimal Scale and Decimals Limit
+
+`decimalsLimit` and `decimalScale` sound similar but have different usages.
+
+`decimalsLimit` prevents the user from typing more than the limit, and `decimalScale` will format the decimals `onBlur` to the specified length, padding or trimming as necessary.
+
+Example:
+
+```md
+If decimalScale is 2
+
+- 1.5 becomes 1.50 (padded)
+- 1.234 becomes 1.23 (trimmed)
+
+---
+
+If decimalLimit is 2
+
+- User enters 1.23
+- User is then prevented from entering another value
+```
+
 ### Fixed Decimal Length
 
 Use `fixedDecimalLength` so that the value will always have the specified length of decimals.
@@ -174,12 +196,6 @@ Example if `fixedDecimalLength` was 2:
 - 12.3 -> 12.30
 - 12.34 -> 12.34
 ```
-
-## Decimal Scale and Decimals Limit
-
-`decimalsLimit` and `decimalScale` are similar, the difference is `decimalsLimit` prevents the user from typing more than the limit, and `decimalScale` will format the decimals `onBlur` to the specified length, padding or trimming as necessary.
-
-Example: If decimal scale `2`: `1.5` becomes `1.50` and `1.234` becomes `1.23`
 
 ## Format values for display
 

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -51,10 +51,6 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
     }: CurrencyInputProps,
     ref
   ) => {
-    if (_decimalSeparator && _groupSeparator && _decimalSeparator === _groupSeparator) {
-      throw new Error('decimalSeparator cannot be the same as groupSeparator');
-    }
-
     if (_decimalSeparator && isNumber(_decimalSeparator)) {
       throw new Error('decimalSeparator cannot be a number');
     }
@@ -66,6 +62,15 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
     const localeConfig = useMemo(() => getLocaleConfig(intlConfig), [intlConfig]);
     const decimalSeparator = _decimalSeparator || localeConfig.decimalSeparator || '';
     const groupSeparator = _groupSeparator || localeConfig.groupSeparator || '';
+
+    if (
+      decimalSeparator &&
+      groupSeparator &&
+      decimalSeparator === groupSeparator &&
+      disableGroupSeparators === false
+    ) {
+      throw new Error('decimalSeparator cannot be the same as groupSeparator');
+    }
 
     const formatValueOptions = {
       decimalSeparator,

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -87,9 +87,9 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
     };
 
     const formattedStateValue =
-      defaultValue !== undefined
+      defaultValue !== undefined && defaultValue !== null
         ? formatValue({ ...formatValueOptions, decimalScale, value: String(defaultValue) })
-        : userValue !== undefined
+        : userValue !== undefined && userValue !== null
         ? formatValue({ ...formatValueOptions, decimalScale, value: String(userValue) })
         : '';
 
@@ -190,7 +190,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
 
         const currentValue =
           parseFloat(
-            userValue !== undefined
+            userValue !== undefined && userValue !== null
               ? String(userValue).replace(decimalSeparator, '.')
               : cleanValue({ value: stateValue, ...cleanValueOptions })
           ) || 0;
@@ -253,7 +253,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
     }, [stateValue, cursor, inputRef, dirty]);
 
     const formattedPropsValue =
-      userValue !== undefined
+      userValue !== undefined && userValue !== null
         ? formatValue({
             ...formatValueOptions,
             decimalScale: dirty ? undefined : decimalScale,

--- a/src/components/__tests__/CurrencyInput-fixedDecimalLength.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-fixedDecimalLength.spec.tsx
@@ -41,21 +41,21 @@ describe('<CurrencyInput/> fixedDecimalLength', () => {
           prefix="$"
           onValueChange={onValueChangeSpy}
           fixedDecimalLength={3}
-          decimalSeparator=","
-          decimalScale={2}
+          decimalSeparator="."
+          decimalScale={3}
           defaultValue={123}
         />
       );
 
-      expect(screen.getByRole('textbox')).toHaveValue('$123,00');
+      expect(screen.getByRole('textbox')).toHaveValue('$123.000');
 
-      // delete ,00
+      // delete .00
       userEvent.type(screen.getByRole('textbox'), '{backspace}{backspace}');
       fireEvent.focusOut(screen.getByRole('textbox'));
 
-      expect(onValueChangeSpy).toBeCalledWith('1,23', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('123.0', undefined);
 
-      expect(screen.getByRole('textbox')).toHaveValue('$1,23');
+      expect(screen.getByRole('textbox')).toHaveValue('$123.000');
     });
   });
 });

--- a/src/components/__tests__/CurrencyInput-separators.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-separators.spec.tsx
@@ -80,6 +80,34 @@ describe('<CurrencyInput/> separators', () => {
       expect(console.error).toHaveBeenCalled();
     });
 
+    it('should throw error if decimalSeparator and default groupSeparator are the same', () => {
+      expect(() => render(<CurrencyInput name={name} prefix="£" decimalSeparator="," />)).toThrow(
+        'decimalSeparator cannot be the same as groupSeparator'
+      );
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it('should NOT throw error if decimalSeparator and default groupSeparator are the same but disableGroupSeparators is true', () => {
+      expect(() =>
+        render(
+          <CurrencyInput
+            name={name}
+            prefix="£"
+            decimalSeparator=","
+            disableGroupSeparators={true}
+          />
+        )
+      ).not.toThrow('decimalSeparator cannot be the same as groupSeparator');
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('should throw error if groupSeparator and default decimalSeparator are the same', () => {
+      expect(() => render(<CurrencyInput name={name} prefix="£" groupSeparator="." />)).toThrow(
+        'decimalSeparator cannot be the same as groupSeparator'
+      );
+      expect(console.error).toHaveBeenCalled();
+    });
+
     it('should throw error if decimalSeparator is a number', () => {
       expect(() =>
         render(<CurrencyInput name={name} prefix="£" decimalSeparator={'1'} groupSeparator="," />)

--- a/src/components/__tests__/CurrencyInput.spec.tsx
+++ b/src/components/__tests__/CurrencyInput.spec.tsx
@@ -42,6 +42,19 @@ describe('<CurrencyInput/>', () => {
     expect(screen.getByRole('textbox')).toHaveValue('£0');
   });
 
+  it('Renders with default value undefined', () => {
+    render(<CurrencyInput defaultValue={undefined} prefix="£" />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
+  it('Renders with default value null', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render(<CurrencyInput defaultValue={null as any} prefix="£" />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
   it('Renders with default value 0 with decimalScale 2', () => {
     render(<CurrencyInput defaultValue={0} decimalScale={2} prefix="£" />);
 
@@ -58,6 +71,19 @@ describe('<CurrencyInput/>', () => {
     render(<CurrencyInput value={0} prefix="£" />);
 
     expect(screen.getByRole('textbox')).toHaveValue('£0');
+  });
+
+  it('Renders with value undefined', () => {
+    render(<CurrencyInput value={undefined} prefix="£" />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
+  it('Renders with value null', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render(<CurrencyInput value={null as any} prefix="£" />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
   });
 
   it('Renders with value 0 with decimalScale 2', () => {

--- a/src/examples/index.html
+++ b/src/examples/index.html
@@ -64,6 +64,6 @@
 
       <footer class="mb-5"></footer>
     </div>
-    <script src="./index.tsx"></script>
+    <script type="module" src="./index.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Changes: 

- `value={null}` should not display `NaN` (#176)
- Throw an error if the `decimalSeparator` is the same as the default `groupSeparator` ( #189 #196 )
- Updated ReadMe