### PR TITLE
feat: onValueChange calls Values object as third param

### DIFF
--- a/src/components/CurrencyInputProps.ts
+++ b/src/components/CurrencyInputProps.ts
@@ -2,6 +2,34 @@ import { Ref, ElementType } from 'react';
 
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
 
+/**
+ * Value in different formats
+ *
+ * @experimental
+ */
+export type Values = {
+  /**
+   * Value as float or null if empty
+   *
+   * Example:
+   *   "1.99" > 1.99
+   *   "" > null
+   */
+  float: number | null;
+
+  /**
+   * Value after applying formatting
+   *
+   * Example: "1000000" > "1,000,0000"
+   */
+  formatted: string;
+
+  /**
+   * Non formatted value as string
+   */
+  value: string;
+};
+
 export type IntlConfig = {
   locale: string;
   currency?: string;
@@ -56,7 +84,9 @@ export type CurrencyInputProps = Overwrite<
     /**
      * Specify decimal scale for padding/trimming
      *
-     * Eg. 1.5 -> 1.50 or 1.234 -> 1.23
+     * Example:
+     *   1.5 -> 1.50
+     *   1.234 -> 1.23
      */
     decimalScale?: number;
 
@@ -75,7 +105,8 @@ export type CurrencyInputProps = Overwrite<
     /**
      * Value will always have the specified length of decimals
      *
-     * Eg. 123 -> 1.23
+     * Example:
+     *   123 -> 1.23
      *
      * Note: This formatting only happens onBlur
      */
@@ -84,7 +115,7 @@ export type CurrencyInputProps = Overwrite<
     /**
      * Handle change in value
      */
-    onValueChange?: (value: string | undefined, name?: string) => void;
+    onValueChange?: (value: string | undefined, name?: string, values?: Values) => void;
 
     /**
      * Placeholder if there is no value
@@ -128,7 +159,7 @@ export type CurrencyInputProps = Overwrite<
     disableGroupSeparators?: boolean;
 
     /**
-     * Disable abbreviations eg. 1k -> 1,000, 2m -> 2,000,000
+     * Disable abbreviations (m, k, b)
      *
      * Default = false
      */

--- a/src/components/__tests__/CurrencyInput-abbreviated.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-abbreviated.spec.tsx
@@ -15,7 +15,11 @@ describe('<CurrencyInput/> abbreviated', () => {
     render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
     userEvent.type(screen.getByRole('textbox'), '1.5k');
 
-    expect(onValueChangeSpy).toBeCalledWith('1500', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1500', undefined, {
+      float: 1500,
+      formatted: '£1,500',
+      value: '1500',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('£1,500');
   });
@@ -27,14 +31,22 @@ describe('<CurrencyInput/> abbreviated', () => {
 
     expect(screen.getByRole('textbox')).toHaveValue('£2,123,000');
 
-    expect(onValueChangeSpy).toBeCalledWith('2123000', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('2123000', undefined, {
+      float: 2123000,
+      formatted: '£2,123,000',
+      value: '2123000',
+    });
   });
 
   it('should allow abbreviated values with b', () => {
     render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} decimalsLimit={3} />);
     userEvent.type(screen.getByRole('textbox'), '1.599B');
 
-    expect(onValueChangeSpy).toBeCalledWith('1599000000', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1599000000', undefined, {
+      float: 1599000000,
+      formatted: '£1,599,000,000',
+      value: '1599000000',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('£1,599,000,000');
   });
@@ -43,7 +55,11 @@ describe('<CurrencyInput/> abbreviated', () => {
     render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
     userEvent.type(screen.getByRole('textbox'), '1.5e');
 
-    expect(onValueChangeSpy).toBeCalledWith('1.5', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1.5', undefined, {
+      float: 1.5,
+      formatted: '£1.5',
+      value: '1.5',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('£1.5');
   });
@@ -52,13 +68,21 @@ describe('<CurrencyInput/> abbreviated', () => {
     render(<CurrencyInput onValueChange={onValueChangeSpy} />);
     userEvent.type(screen.getByRole('textbox'), 'k');
 
-    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith(undefined, undefined, {
+      float: null,
+      formatted: '',
+      value: '',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('');
 
     userEvent.type(screen.getByRole('textbox'), 'M');
 
-    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith(undefined, undefined, {
+      float: null,
+      formatted: '',
+      value: '',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('');
   });
@@ -73,14 +97,22 @@ describe('<CurrencyInput/> abbreviated', () => {
       userEvent.clear(screen.getByRole('textbox'));
       userEvent.type(screen.getByRole('textbox'), '23m');
 
-      expect(onValueChangeSpy).toBeCalledWith('23', undefined);
+      expect(onValueChangeSpy).toHaveBeenLastCalledWith('23', undefined, {
+        float: 23,
+        formatted: '23',
+        value: '23',
+      });
 
       expect(screen.getByRole('textbox')).toHaveValue('23');
 
       userEvent.clear(screen.getByRole('textbox'));
       userEvent.type(screen.getByRole('textbox'), '55b');
 
-      expect(onValueChangeSpy).toBeCalledWith('55', undefined);
+      expect(onValueChangeSpy).toHaveBeenLastCalledWith('55', undefined, {
+        float: 55,
+        formatted: '55',
+        value: '55',
+      });
 
       expect(screen.getByRole('textbox')).toHaveValue('55');
     });

--- a/src/components/__tests__/CurrencyInput-backspace.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-backspace.spec.tsx
@@ -25,10 +25,20 @@ describe('<CurrencyInput/> backspace', () => {
 
     userEvent.type(screen.getByRole('textbox'), '56');
 
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('12,3456', undefined, {
+      float: 12.3456,
+      formatted: '12,3456 €',
+      value: '12,3456',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('12,3456\xa0€');
 
     userEvent.type(screen.getByRole('textbox'), '{backspace}{backspace}{backspace}');
 
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('12,3', undefined, {
+      float: 12.3,
+      formatted: '12,3 €',
+      value: '12,3',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('12,3\xa0€');
   });
 
@@ -45,15 +55,39 @@ describe('<CurrencyInput/> backspace', () => {
     expect(screen.getByRole('textbox')).toHaveValue('£1.00');
 
     userEvent.type(screen.getByRole('textbox'), '{backspace}');
+
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1.0', undefined, {
+      float: 1,
+      formatted: '£1.0',
+      value: '1.0',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£1.0');
 
     userEvent.type(screen.getByRole('textbox'), '{backspace}');
+
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1.', undefined, {
+      float: 1,
+      formatted: '£1.',
+      value: '1.',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£1.');
 
     userEvent.type(screen.getByRole('textbox'), '{backspace}');
+
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1', undefined, {
+      float: 1,
+      formatted: '£1',
+      value: '1',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£1');
 
     userEvent.type(screen.getByRole('textbox'), '{backspace}');
+
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith(undefined, undefined, {
+      float: null,
+      formatted: '',
+      value: '',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('');
   });
 
@@ -69,9 +103,21 @@ describe('<CurrencyInput/> backspace', () => {
     );
 
     userEvent.type(screen.getByRole('textbox'), '123456789');
+
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('123456789', undefined, {
+      float: 123456789,
+      formatted: '$123,456,789',
+      value: '123456789',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('$123,456,789');
 
     userEvent.type(screen.getByRole('textbox'), '{arrowleft}{arrowleft}{arrowleft}{del}');
+
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('12345689', undefined, {
+      float: 12345689,
+      formatted: '$12,345,689',
+      value: '12345689',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('$12,345,689');
   });
 });

--- a/src/components/__tests__/CurrencyInput-decimals.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-decimals.spec.tsx
@@ -15,7 +15,11 @@ describe('<CurrencyInput/> decimals', () => {
     render(<CurrencyInput allowDecimals={true} prefix="£" onValueChange={onValueChangeSpy} />);
     userEvent.type(screen.getByRole('textbox'), '1,234.56');
 
-    expect(onValueChangeSpy).toBeCalledWith('1234.56', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1234.56', undefined, {
+      float: 1234.56,
+      formatted: '£1,234.56',
+      value: '1234.56',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('£1,234.56');
   });
@@ -24,7 +28,11 @@ describe('<CurrencyInput/> decimals', () => {
     render(<CurrencyInput allowDecimals={false} prefix="£" onValueChange={onValueChangeSpy} />);
     userEvent.type(screen.getByRole('textbox'), '1,234.56');
 
-    expect(onValueChangeSpy).toBeCalledWith('123456', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('123456', undefined, {
+      float: 123456,
+      formatted: '£123,456',
+      value: '123456',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('£123,456');
   });
@@ -33,7 +41,11 @@ describe('<CurrencyInput/> decimals', () => {
     render(<CurrencyInput decimalsLimit={3} prefix="£" onValueChange={onValueChangeSpy} />);
     userEvent.type(screen.getByRole('textbox'), '1,234.56789');
 
-    expect(onValueChangeSpy).toBeCalledWith('1234.567', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1234.567', undefined, {
+      float: 1234.567,
+      formatted: '£1,234.567',
+      value: '1234.567',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('£1,234.567');
   });
@@ -52,12 +64,20 @@ describe('<CurrencyInput/> decimals', () => {
     userEvent.type(screen.getByRole('textbox'), '.');
 
     expect(screen.getByRole('textbox')).toHaveValue('.');
-    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith(undefined, undefined, {
+      float: null,
+      formatted: '',
+      value: '',
+    });
 
     userEvent.type(screen.getByRole('textbox'), '9');
 
     expect(screen.getByRole('textbox')).toHaveValue('$0.9');
-    expect(onValueChangeSpy).toBeCalledWith('.9', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('.9', undefined, {
+      float: 0.9,
+      formatted: '$0.9',
+      value: '.9',
+    });
   });
 
   it('should handle starting with decimal separator that is non period', () => {
@@ -73,11 +93,19 @@ describe('<CurrencyInput/> decimals', () => {
     userEvent.type(screen.getByRole('textbox'), ',');
 
     expect(screen.getByRole('textbox')).toHaveValue(',');
-    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith(undefined, undefined, {
+      float: null,
+      formatted: '',
+      value: '',
+    });
 
     userEvent.type(screen.getByRole('textbox'), '9');
 
     expect(screen.getByRole('textbox')).toHaveValue('0,9\xa0€');
-    expect(onValueChangeSpy).toBeCalledWith(',9', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith(',9', undefined, {
+      float: 0.9,
+      formatted: '0,9 €',
+      value: ',9',
+    });
   });
 });

--- a/src/components/__tests__/CurrencyInput-fixedDecimalLength.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-fixedDecimalLength.spec.tsx
@@ -30,7 +30,11 @@ describe('<CurrencyInput/> fixedDecimalLength', () => {
 
       fireEvent.focusOut(screen.getByRole('textbox'));
 
-      expect(onValueChangeSpy).toBeCalledWith('1.230', undefined);
+      expect(onValueChangeSpy).toHaveBeenLastCalledWith('1.230', undefined, {
+        float: 1.23,
+        formatted: '$1.230',
+        value: '1.230',
+      });
 
       expect(screen.getByRole('textbox')).toHaveValue('$1.230');
     });
@@ -40,22 +44,27 @@ describe('<CurrencyInput/> fixedDecimalLength', () => {
         <CurrencyInput
           prefix="$"
           onValueChange={onValueChangeSpy}
-          fixedDecimalLength={3}
+          fixedDecimalLength={2}
           decimalSeparator="."
-          decimalScale={3}
-          defaultValue={123}
+          defaultValue={1}
+          decimalScale={2}
         />
       );
 
-      expect(screen.getByRole('textbox')).toHaveValue('$123.000');
+      expect(screen.getByRole('textbox')).toHaveValue('$1.00');
 
       // delete .00
       userEvent.type(screen.getByRole('textbox'), '{backspace}{backspace}');
+      userEvent.type(screen.getByRole('textbox'), '23');
       fireEvent.focusOut(screen.getByRole('textbox'));
 
-      expect(onValueChangeSpy).toBeCalledWith('123.0', undefined);
+      expect(onValueChangeSpy).toHaveBeenLastCalledWith('1.23', undefined, {
+        float: 1.23,
+        formatted: '$1.23',
+        value: '1.23',
+      });
 
-      expect(screen.getByRole('textbox')).toHaveValue('$123.000');
+      expect(screen.getByRole('textbox')).toHaveValue('$1.23');
     });
   });
 });

--- a/src/components/__tests__/CurrencyInput-handleKeyDown.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-handleKeyDown.spec.tsx
@@ -31,11 +31,19 @@ describe('<CurrencyInput/> handleKeyDown', () => {
     );
 
     userEvent.type(screen.getByRole('textbox'), '{arrowup}');
-    expect(onValueChangeSpy).toHaveBeenCalledWith('98', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('98', undefined, {
+      float: 98,
+      formatted: '£98',
+      value: '98',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£98');
 
     userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
-    expect(onValueChangeSpy).toHaveBeenCalledWith('100', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('100', undefined, {
+      float: 100,
+      formatted: '£100',
+      value: '100',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£100');
   });
 
@@ -44,7 +52,11 @@ describe('<CurrencyInput/> handleKeyDown', () => {
       render(<CurrencyInput prefix="£" step={1} onValueChange={onValueChangeSpy} />);
 
       userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
-      expect(onValueChangeSpy).toBeCalledWith('-1', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('-1', undefined, {
+        float: -1,
+        formatted: '-£1',
+        value: '-1',
+      });
       expect(screen.getByRole('textbox')).toHaveValue('-£1');
     });
 
@@ -52,7 +64,11 @@ describe('<CurrencyInput/> handleKeyDown', () => {
       render(<CurrencyInput prefix="£" step={1} onValueChange={onValueChangeSpy} />);
 
       userEvent.type(screen.getByRole('textbox'), '{arrowup}');
-      expect(onValueChangeSpy).toBeCalledWith('1', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('1', undefined, {
+        float: 1,
+        formatted: '£1',
+        value: '1',
+      });
       expect(screen.getByRole('textbox')).toHaveValue('£1');
     });
   });
@@ -62,14 +78,22 @@ describe('<CurrencyInput/> handleKeyDown', () => {
       render(<CurrencyInput prefix="£" value={99} step={1.25} onValueChange={onValueChangeSpy} />);
 
       userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
-      expect(onValueChangeSpy).toHaveBeenCalledWith('97.75', undefined);
+      expect(onValueChangeSpy).toHaveBeenLastCalledWith('97.75', undefined, {
+        float: 97.75,
+        formatted: '£97.75',
+        value: '97.75',
+      });
     });
 
     it('should handle arrow up key', () => {
       render(<CurrencyInput prefix="£" value={99} step={1.25} onValueChange={onValueChangeSpy} />);
 
       userEvent.type(screen.getByRole('textbox'), '{arrowup}');
-      expect(onValueChangeSpy).toHaveBeenCalledWith('100.25', undefined);
+      expect(onValueChangeSpy).toHaveBeenLastCalledWith('100.25', undefined, {
+        float: 100.25,
+        formatted: '£100.25',
+        value: '100.25',
+      });
     });
   });
 
@@ -80,11 +104,19 @@ describe('<CurrencyInput/> handleKeyDown', () => {
       );
 
       userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
-      expect(onValueChangeSpy).toBeCalledWith('94.5', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('94.5', undefined, {
+        float: 94.5,
+        formatted: '£94.5',
+        value: '94.5',
+      });
       expect(screen.getByRole('textbox')).toHaveValue('£94.5');
 
       userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
-      expect(onValueChangeSpy).toBeCalledWith('89.0', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('89.0', undefined, {
+        float: 89,
+        formatted: '£89.0',
+        value: '89.0',
+      });
       expect(screen.getByRole('textbox')).toHaveValue('£89.0');
     });
 
@@ -94,11 +126,19 @@ describe('<CurrencyInput/> handleKeyDown', () => {
       );
 
       userEvent.type(screen.getByRole('textbox'), '{arrowup}');
-      expect(onValueChangeSpy).toBeCalledWith('105.5', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('105.5', undefined, {
+        float: 105.5,
+        formatted: '£105.5',
+        value: '105.5',
+      });
       expect(screen.getByRole('textbox')).toHaveValue('£105.5');
 
       userEvent.type(screen.getByRole('textbox'), '{arrowup}');
-      expect(onValueChangeSpy).toBeCalledWith('111.0', undefined);
+      expect(onValueChangeSpy).toBeCalledWith('111.0', undefined, {
+        float: 111,
+        formatted: '£111.0',
+        value: '111.0',
+      });
       expect(screen.getByRole('textbox')).toHaveValue('£111.0');
     });
   });
@@ -120,7 +160,11 @@ describe('<CurrencyInput/> handleKeyDown', () => {
       expect(screen.getByRole('textbox')).toHaveValue('-£99');
 
       userEvent.type(screen.getByRole('textbox'), '{arrowup}');
-      expect(onValueChangeSpy).toHaveBeenCalledWith('-98', undefined);
+      expect(onValueChangeSpy).toHaveBeenLastCalledWith('-98', undefined, {
+        float: -98,
+        formatted: '-£98',
+        value: '-98',
+      });
       expect(screen.getByRole('textbox')).toHaveValue('-£98');
     });
 
@@ -140,7 +184,11 @@ describe('<CurrencyInput/> handleKeyDown', () => {
       expect(screen.getByRole('textbox')).toHaveValue('£99');
 
       userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
-      expect(onValueChangeSpy).toHaveBeenCalledWith('98', undefined);
+      expect(onValueChangeSpy).toHaveBeenLastCalledWith('98', undefined, {
+        float: 98,
+        formatted: '£98',
+        value: '98',
+      });
       expect(screen.getByRole('textbox')).toHaveValue('£98');
     });
   });
@@ -153,19 +201,35 @@ describe('<CurrencyInput/> handleKeyDown', () => {
     expect(screen.getByRole('textbox')).toHaveValue('£1.99');
 
     userEvent.type(screen.getByRole('textbox'), '{arrowup}');
-    expect(onValueChangeSpy).toHaveBeenCalledWith('2.99', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('2.99', undefined, {
+      float: 2.99,
+      formatted: '£2.99',
+      value: '2.99',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£2.99');
 
     userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
-    expect(onValueChangeSpy).toHaveBeenCalledWith('1.99', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1.99', undefined, {
+      float: 1.99,
+      formatted: '£1.99',
+      value: '1.99',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£1.99');
 
     userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
-    expect(onValueChangeSpy).toHaveBeenCalledWith('0.99', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('0.99', undefined, {
+      float: 0.99,
+      formatted: '£0.99',
+      value: '0.99',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£0.99');
 
     userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
-    expect(onValueChangeSpy).toHaveBeenCalledWith('-0.01', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('-0.01', undefined, {
+      float: -0.01,
+      formatted: '-£0.01',
+      value: '-0.01',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('-£0.01');
   });
 
@@ -184,15 +248,27 @@ describe('<CurrencyInput/> handleKeyDown', () => {
     expect(screen.getByRole('textbox')).toHaveValue('£1.00');
 
     userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
-    expect(onValueChangeSpy).toHaveBeenCalledWith('0', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('0', undefined, {
+      float: 0,
+      formatted: '£0',
+      value: '0',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£0');
 
     userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
-    expect(onValueChangeSpy).toHaveBeenCalledWith('0', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('0', undefined, {
+      float: 0,
+      formatted: '£0',
+      value: '0',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£0');
 
     userEvent.type(screen.getByRole('textbox'), '{arrowup}');
-    expect(onValueChangeSpy).toHaveBeenCalledWith('1', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1', undefined, {
+      float: 1,
+      formatted: '£1',
+      value: '1',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£1');
   });
 
@@ -210,15 +286,27 @@ describe('<CurrencyInput/> handleKeyDown', () => {
     expect(screen.getByRole('textbox')).toHaveValue('£44');
 
     userEvent.type(screen.getByRole('textbox'), '{arrowup}');
-    expect(onValueChangeSpy).toHaveBeenCalledWith('45', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('45', undefined, {
+      float: 45,
+      formatted: '£45',
+      value: '45',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£45');
 
     userEvent.type(screen.getByRole('textbox'), '{arrowup}');
-    expect(onValueChangeSpy).toHaveBeenCalledWith('45', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('45', undefined, {
+      float: 45,
+      formatted: '£45',
+      value: '45',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£45');
 
     userEvent.type(screen.getByRole('textbox'), '{arrowdown}');
-    expect(onValueChangeSpy).toHaveBeenCalledWith('44', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('44', undefined, {
+      float: 44,
+      formatted: '£44',
+      value: '44',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('£44');
   });
 });

--- a/src/components/__tests__/CurrencyInput-intl-config.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-intl-config.spec.tsx
@@ -103,7 +103,11 @@ describe('<CurrencyInput/> intlConfig', () => {
 
       userEvent.type(screen.getByRole('textbox'), '₹12,34,567');
 
-      expect(onValueChangeSpy).toBeCalledWith('1234567', undefined);
+      expect(onValueChangeSpy).toHaveBeenLastCalledWith('1234567', undefined, {
+        float: 1234567,
+        formatted: '₹12,34,567',
+        value: '1234567',
+      });
 
       expect(screen.getByRole('textbox')).toHaveValue('₹12,34,567');
     });

--- a/src/components/__tests__/CurrencyInput-maxLength.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-maxLength.spec.tsx
@@ -41,7 +41,11 @@ describe('<CurrencyInput/> maxLength', () => {
     expect(screen.getByRole('textbox')).toHaveValue('-£123');
 
     userEvent.type(screen.getByRole('textbox'), '{backspace}5');
-    expect(onValueChangeSpy).toHaveBeenCalledWith('-125', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('-125', undefined, {
+      float: -125,
+      formatted: '-£125',
+      value: '-125',
+    });
     expect(screen.getByRole('textbox')).toHaveValue('-£125');
   });
 });

--- a/src/components/__tests__/CurrencyInput-negative.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-negative.spec.tsx
@@ -28,7 +28,11 @@ describe('<CurrencyInput/> negative value', () => {
 
     userEvent.clear(screen.getByRole('textbox'));
     userEvent.type(screen.getByRole('textbox'), '-1234');
-    expect(onValueChangeSpy).toBeCalledWith('-1234', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('-1234', undefined, {
+      float: -1234,
+      formatted: '-$1,234',
+      value: '-1234',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('-$1,234');
   });
@@ -48,7 +52,11 @@ describe('<CurrencyInput/> negative value', () => {
 
     userEvent.clear(screen.getByRole('textbox'));
     userEvent.type(screen.getByRole('textbox'), '-');
-    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith(undefined, undefined, {
+      float: null,
+      formatted: '',
+      value: '',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('-');
   });
@@ -72,7 +80,11 @@ describe('<CurrencyInput/> negative value', () => {
     );
     expect(screen.getByRole('textbox')).toHaveValue('-');
     expect(onValueChangeSpy).toBeCalledTimes(7);
-    expect(onValueChangeSpy).toHaveBeenLastCalledWith(undefined, undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith(undefined, undefined, {
+      float: null,
+      formatted: '',
+      value: '',
+    });
 
     fireEvent.focusOut(screen.getByRole('textbox'));
     expect(screen.getByRole('textbox')).toHaveValue('');
@@ -93,7 +105,11 @@ describe('<CurrencyInput/> negative value', () => {
 
     userEvent.clear(screen.getByRole('textbox'));
     userEvent.type(screen.getByRole('textbox'), '-1234');
-    expect(onValueChangeSpy).toBeCalledWith('1234', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1234', undefined, {
+      float: 1234,
+      formatted: '$1,234',
+      value: '1234',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('$1,234');
   });

--- a/src/components/__tests__/CurrencyInput-onBlur.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-onBlur.spec.tsx
@@ -31,7 +31,11 @@ describe('<CurrencyInput/> onBlur', () => {
 
     expect(onBlurSpy).toBeCalled();
 
-    expect(onValueChangeSpy).toBeCalledWith('123.00', name);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('123.00', name, {
+      float: 123,
+      formatted: '$123.00',
+      value: '123.00',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('$123.00');
   });

--- a/src/components/__tests__/CurrencyInput-precision.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-precision.spec.tsx
@@ -17,7 +17,11 @@ describe('<CurrencyInput/> decimalScale', () => {
     userEvent.type(screen.getByRole('textbox'), '1.5');
     fireEvent.focusOut(screen.getByRole('textbox'));
 
-    expect(onValueChangeSpy).toBeCalledWith('1.50000', undefined);
+    expect(onValueChangeSpy).toBeCalledWith('1.50000', undefined, {
+      float: 1.5,
+      formatted: '£1.50000',
+      value: '1.50000',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('£1.50000');
   });
@@ -38,7 +42,11 @@ describe('<CurrencyInput/> decimalScale', () => {
 
     expect(onBlurSpy).toBeCalled();
 
-    expect(onValueChangeSpy).toBeCalledWith('1.00', undefined);
+    expect(onValueChangeSpy).toBeCalledWith('1.00', undefined, {
+      float: 1,
+      formatted: '£1.00',
+      value: '1.00',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('£1.00');
   });

--- a/src/components/__tests__/CurrencyInput-separators.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-separators.spec.tsx
@@ -28,7 +28,11 @@ describe('<CurrencyInput/> separators', () => {
 
     userEvent.clear(screen.getByRole('textbox'));
     userEvent.type(screen.getByRole('textbox'), '123456');
-    expect(onValueChangeSpy).toBeCalledWith('123456', name);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('123456', name, {
+      float: 123456,
+      formatted: '£123456',
+      value: '123456',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('£123456');
   });
@@ -46,7 +50,11 @@ describe('<CurrencyInput/> separators', () => {
 
     userEvent.clear(screen.getByRole('textbox'));
     userEvent.type(screen.getByRole('textbox'), '123456,33');
-    expect(onValueChangeSpy).toHaveBeenLastCalledWith('123456,33', name);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('123456,33', name, {
+      float: 123456.33,
+      formatted: '£123.456,33',
+      value: '123456,33',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('£123.456,33');
   });

--- a/src/components/__tests__/CurrencyInput.spec.tsx
+++ b/src/components/__tests__/CurrencyInput.spec.tsx
@@ -113,7 +113,11 @@ describe('<CurrencyInput/>', () => {
     render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
     userEvent.type(screen.getByRole('textbox'), '100');
 
-    expect(onValueChangeSpy).toBeCalledWith('100', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('100', undefined, {
+      float: 100,
+      formatted: '£100',
+      value: '100',
+    });
   });
 
   it('should prefix 0 value', () => {
@@ -126,7 +130,11 @@ describe('<CurrencyInput/>', () => {
     render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
     userEvent.type(screen.getByRole('textbox'), '0');
 
-    expect(onValueChangeSpy).toBeCalledWith('0', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('0', undefined, {
+      float: 0,
+      formatted: '£0',
+      value: '0',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('£0');
   });
@@ -135,7 +143,11 @@ describe('<CurrencyInput/>', () => {
     render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} defaultValue={1} />);
     userEvent.clear(screen.getByRole('textbox'));
 
-    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith(undefined, undefined, {
+      float: null,
+      formatted: '',
+      value: '',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('');
   });
@@ -145,14 +157,22 @@ describe('<CurrencyInput/>', () => {
     render(<CurrencyInput name={name} prefix="£" onValueChange={onValueChangeSpy} />);
     userEvent.type(screen.getByRole('textbox'), '123');
 
-    expect(onValueChangeSpy).toBeCalledWith('123', name);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('123', name, {
+      float: 123,
+      formatted: '£123',
+      value: '123',
+    });
   });
 
   it('should not allow invalid characters', () => {
     render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
     userEvent.type(screen.getByRole('textbox'), 'hello');
 
-    expect(onValueChangeSpy).toBeCalledWith(undefined, undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith(undefined, undefined, {
+      float: null,
+      formatted: '',
+      value: '',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('');
   });
@@ -161,7 +181,11 @@ describe('<CurrencyInput/>', () => {
     render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
     userEvent.type(screen.getByRole('textbox'), '£123hello');
 
-    expect(onValueChangeSpy).toBeCalledWith('123', undefined);
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('123', undefined, {
+      float: 123,
+      formatted: '£123',
+      value: '123',
+    });
 
     expect(screen.getByRole('textbox')).toHaveValue('£123');
   });


### PR DESCRIPTION
`onValueChange` callback can accept a third param for `Values` object, which will contain `{ float, formatted, value }`
