### PR TITLE
Fix Webpack 5 warnings with Create React App

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "3.6.0",
   "description": "React <input/> component for formatting currency and numbers.",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "src/**/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
The package was shipping source maps in `dist` pointing to paths like `../src/components`, so Webpack threw a warning when it couldn't find them.

This PR ships the source code in the package so source maps don't point to nothing. One other solution would be not to use source maps, but this one is probably nicer for DX :)

Fixes #210 