### PR TITLE
fix formatting not working for 'es' locale

### DIFF
--- a/src/components/utils/getLocaleConfig.ts
+++ b/src/components/utils/getLocaleConfig.ts
@@ -25,7 +25,7 @@ export const getLocaleConfig = (intlConfig?: IntlConfig): LocaleConfig => {
     ? new Intl.NumberFormat(locale, currency ? { currency, style: 'currency' } : undefined)
     : new Intl.NumberFormat();
 
-  return numberFormatter.formatToParts(1000.1).reduce((prev, curr, i): LocaleConfig => {
+  return numberFormatter.formatToParts(10000.1).reduce((prev, curr, i): LocaleConfig => {
     if (curr.type === 'currency') {
       if (i === 0) {
         return { ...prev, currencySymbol: curr.value, prefix: curr.value };


### PR DESCRIPTION
**Steps to reproduce:**
- Use the prop `intlConfig` with `locale: "es"` in the component
- You will notice that the formatting doesn't work, for eg: `123456.78` should be formatted to `123.456,78` but instead, it gets formatted to `123456,78`

**Reason:**
- It is because the `getLocaleConfig` function is not returning the group separator for `es` locale.
- And this is happening because the `formatToParts` function is given the value `1000.1` to get the separators but the `Intl.NumberFormat` function only starts to format after 5 digits before decimal, in case of `es` locale
_(See image for more clarity)_

![Screenshot from 2022-05-05 14-53-30](https://user-images.githubusercontent.com/46838072/166898080-be862509-5f11-4cac-86c2-b9634fe72046.png)
- Notice we don't get the `group` separator, unless we format a **5 digits**(excluding decimal) number.

**Solution:**
- We just need to pass 5 digit number(`10000.1`) to the `formatToParts` function, so that we get a valid group separator.


I know that's too much explanation for a single line of change, but I just wanted to make things clear for other people who see this. 😄


