### PR TITLE
fix getSuffix when group separator is same as a literal

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -65,6 +65,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
     const localeConfig = useMemo(() => getLocaleConfig(intlConfig), [intlConfig]);
     const decimalSeparator = _decimalSeparator || localeConfig.decimalSeparator || '';
     const groupSeparator = _groupSeparator || localeConfig.groupSeparator || '';
+    const literalSeparator = localeConfig.literalSeparator;
 
     if (
       decimalSeparator &&
@@ -78,6 +79,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
     const formatValueOptions: Partial<FormatValueOptions> = {
       decimalSeparator,
       groupSeparator,
+      literalSeparator,
       disableGroupSeparators,
       intlConfig,
       prefix: prefix || localeConfig.prefix,
@@ -286,7 +288,11 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
         currentTarget: { selectionStart },
       } = event;
       if (key !== 'ArrowUp' && key !== 'ArrowDown' && stateValue !== '-') {
-        const suffix = getSuffix(stateValue, { groupSeparator, decimalSeparator });
+        const suffix = getSuffix(stateValue, {
+          groupSeparator,
+          decimalSeparator,
+          literalSeparator,
+        });
 
         if (suffix && selectionStart && selectionStart > stateValue.length - suffix.length) {
           /* istanbul ignore else */

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -23,6 +23,13 @@ export type FormatValueOptions = {
   groupSeparator?: string;
 
   /**
+   * Literal separator
+   *
+   * Default = undefined
+   */
+  literalSeparator?: string;
+
+  /**
    * Turn off separators
    *
    * This will override Group separators
@@ -170,9 +177,15 @@ const replaceParts = (
     decimalSeparator,
     decimalScale,
     disableGroupSeparators = false,
+    literalSeparator,
   }: Pick<
     FormatValueOptions,
-    'prefix' | 'groupSeparator' | 'decimalSeparator' | 'decimalScale' | 'disableGroupSeparators'
+    | 'prefix'
+    | 'groupSeparator'
+    | 'decimalSeparator'
+    | 'literalSeparator'
+    | 'decimalScale'
+    | 'disableGroupSeparators'
   >
 ): string => {
   return parts
@@ -206,6 +219,10 @@ const replaceParts = (
           }
 
           return [...prev, decimalSeparator !== undefined ? decimalSeparator : value];
+        }
+
+        if (type === 'literal') {
+          return [...prev, literalSeparator !== undefined ? literalSeparator : value];
         }
 
         if (type === 'fraction') {

--- a/src/components/utils/getLocaleConfig.ts
+++ b/src/components/utils/getLocaleConfig.ts
@@ -4,6 +4,7 @@ type LocaleConfig = {
   currencySymbol: string;
   groupSeparator: string;
   decimalSeparator: string;
+  literalSeparator: string;
   prefix: string;
   suffix: string;
 };
@@ -12,6 +13,7 @@ const defaultConfig: LocaleConfig = {
   currencySymbol: '',
   groupSeparator: '',
   decimalSeparator: '',
+  literalSeparator: '',
   prefix: '',
   suffix: '',
 };
@@ -38,6 +40,9 @@ export const getLocaleConfig = (intlConfig?: IntlConfig): LocaleConfig => {
     }
     if (curr.type === 'decimal') {
       return { ...prev, decimalSeparator: curr.value };
+    }
+    if (curr.type === 'literal') {
+      return { ...prev, literalSeparator: curr.value };
     }
 
     return prev;

--- a/src/components/utils/getSuffix.ts
+++ b/src/components/utils/getSuffix.ts
@@ -2,14 +2,17 @@ import { escapeRegExp } from './escapeRegExp';
 type Options = {
   decimalSeparator?: string;
   groupSeparator?: string;
+  literalSeparator?: string;
 };
 
 export const getSuffix = (
   value: string,
-  { groupSeparator = ',', decimalSeparator = '.' }: Options
+  { groupSeparator = ',', decimalSeparator = '.', literalSeparator = undefined }: Options
 ): string | undefined => {
   const suffixReg = new RegExp(
-    `\\d([^${escapeRegExp(groupSeparator)}${escapeRegExp(decimalSeparator)}0-9]+)`
+    `\\d(${literalSeparator ? escapeRegExp(literalSeparator) + '?' : ''}[^${escapeRegExp(
+      groupSeparator
+    )}${escapeRegExp(decimalSeparator)}0-9]+)`
   );
   const suffixMatch = value.match(suffixReg);
   return suffixMatch ? suffixMatch[1] : undefined;


### PR DESCRIPTION
Fixes a bug in `getSuffix()` for `intlConfig={{ locale: "sv-SE", currency: "SEK" }}` caused by `groupSeparator` being `\u00a0` while `\u00a0` is also used to separate the numbers and the currency label.