### PR TITLE
fix: parse float for currencies w/o decimal sep

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "build": "rm -rf dist && tsc && rollup -c",
     "start": "parcel src/examples/index.html",
-    "test": "jest --coverage --roots ./src",
-    "test-ci": "cross-env NODE_ICU_DATA=node_modules/full-icu jest --coverage",
+    "test": "LANG=en_GB jest --coverage --roots ./src",
+    "test-ci": "LANG=en_GB.UTF-8 cross-env NODE_ICU_DATA=node_modules/full-icu jest --coverage",
     "typecheck": "tsc && tsc --project tsconfig.test.json",
     "lint": "eslint src --max-warnings=0",
     "gh-predeploy": "parcel build src/examples/index.html --dist-dir demo/examples --public-url ./",

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -135,12 +135,11 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
         return;
       }
 
-      const numberValue = (() => {
-        const stringValueWithoutSeparator = decimalSeparator
-          ? stringValue.replace(decimalSeparator, '.')
-          : stringValue;
-        return parseFloat(stringValueWithoutSeparator);
-      })();
+      const stringValueWithoutSeparator = decimalSeparator
+        ? stringValue.replace(decimalSeparator, '.')
+        : stringValue;
+
+      const numberValue = parseFloat(stringValueWithoutSeparator);
 
       const formattedValue = formatValue({
         value: stringValue,

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -135,7 +135,12 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
         return;
       }
 
-      const numberValue = parseFloat(stringValue.replace(decimalSeparator, '.'));
+      const numberValue = (() => {
+        const stringValueWithoutSeparator = decimalSeparator
+          ? stringValue.replace(decimalSeparator, '.')
+          : stringValue;
+        return parseFloat(stringValueWithoutSeparator);
+      })();
 
       const formattedValue = formatValue({
         value: stringValue,

--- a/src/components/__tests__/CurrencyInput-decimals.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-decimals.spec.tsx
@@ -80,6 +80,26 @@ describe('<CurrencyInput/> decimals', () => {
     });
   });
 
+  it('should handle currencies without decimals', () => {
+    render(
+      <CurrencyInput
+        intlConfig={{ locale: 'ja-JP', currency: 'JPY' }}
+        onValueChange={onValueChangeSpy}
+      />
+    );
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+
+    userEvent.type(screen.getByRole('textbox'), '1');
+
+    expect(screen.getByRole('textbox')).toHaveValue('￥1');
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1', undefined, {
+      float: 1,
+      formatted: '￥1',
+      value: '1',
+    });
+  });
+
   it('should handle starting with decimal separator that is non period', () => {
     render(
       <CurrencyInput


### PR DESCRIPTION
* Replace the decimal separator from value only when the former is not an empty string.  Otherwise, `'1'.replace('', '.')` returns `.1`.
* Allow tests to be run from machines which have different locales. The reason is that Intl.NumberFormat constructor falls back to the machine's LANG.