### PR TITLE
fix: safari cursor stuck if onBlur & decimalScale set

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -307,7 +307,8 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
         stateValue !== '-' &&
         inputRef &&
         typeof inputRef === 'object' &&
-        inputRef.current
+        inputRef.current &&
+        document.activeElement === inputRef.current
       ) {
         inputRef.current.setSelectionRange(cursor, cursor);
       }


### PR DESCRIPTION
# Issue
In the following scenario:
- On the master branch
- Using Safari on MacOS
- Having set `decimalScale={2}` for the component

Doing the following:
- Go to "Example 1" (make sure you have "Example 2" in the viewport to jump to another input later)
- Click on the input
- Insert "123"
- Place your cursor on "Example 2" input and click
- **Notice that the cursor gets stuck and you need to click again to focus on the example 2 input**

## Reason:
I was implementing a regular form with this input and it gets stuck in this specific case which would be annoying for the users.