### PR TITLE
fix: no decimals if defined decimalScale, input value as  X.00 and intlConfig, but without no currency

### DIFF
--- a/src/components/utils/__tests__/formatValue.spec.ts
+++ b/src/components/utils/__tests__/formatValue.spec.ts
@@ -526,5 +526,15 @@ describe('formatValue', () => {
         })
       ).toEqual(`123.00`);
     });
+
+    it('should add decimals if intlConfig has no currency provided, decimalScale defined and the input value is X.00', () => {
+      expect(
+        formatValue({
+          value: '123.00',
+          intlConfig: { locale: 'de-DE' },
+          decimalScale: 2,
+        })
+      ).toEqual(`123,00`);
+    });
   });
 });

--- a/src/components/utils/__tests__/formatValue.spec.ts
+++ b/src/components/utils/__tests__/formatValue.spec.ts
@@ -516,5 +516,15 @@ describe('formatValue', () => {
         })
       ).toEqual(`£123.98$`);
     });
+
+    it('should add decimals if intlConfig has no currency provided, decimalScale defined and the input value is X.00', () => {
+      expect(
+        formatValue({
+          value: '123.00',
+          intlConfig: { locale: 'en-US' },
+          decimalScale: 2,
+        })
+      ).toEqual(`123.00`);
+    });
   });
 });

--- a/src/components/utils/__tests__/formatValue.spec.ts
+++ b/src/components/utils/__tests__/formatValue.spec.ts
@@ -527,7 +527,7 @@ describe('formatValue', () => {
       ).toEqual(`123.00`);
     });
 
-    it('should add decimals if intlConfig has no currency provided, decimalScale defined and the input value is X.00', () => {
+    it('should add decimals if intlConfig has no currency provided, decimalScale defined and the input value is X.00 (de-DE)', () => {
       expect(
         formatValue({
           value: '123.00',

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -84,22 +84,23 @@ export const formatValue = (options: FormatValueOptions): string => {
       ? replaceDecimalSeparator(_value, decimalSeparator, isNegative)
       : _value;
 
+  const defaultNumberFormatOptions = {
+    minimumFractionDigits: decimalScale || 0,
+    maximumFractionDigits: 20,
+  };
+
   const numberFormatter = intlConfig
     ? new Intl.NumberFormat(
         intlConfig.locale,
         intlConfig.currency
           ? {
+              ...defaultNumberFormatOptions,
               style: 'currency',
               currency: intlConfig.currency,
-              minimumFractionDigits: decimalScale || 0,
-              maximumFractionDigits: 20,
             }
-          : undefined
+          : defaultNumberFormatOptions
       )
-    : new Intl.NumberFormat(undefined, {
-        minimumFractionDigits: decimalScale || 0,
-        maximumFractionDigits: 20,
-      });
+    : new Intl.NumberFormat(undefined, defaultNumberFormatOptions);
 
   const parts = numberFormatter.formatToParts(Number(value));
 


### PR DESCRIPTION
# Issue
Having the following configuration options:
- value: `123.00`
- decimalScale: `2`
- provide intlConfig, but without specifying the currency, e.g., just `{ locale: "en-US" }`

We'd expect `123.00` but receive `123`

Now it's fixed 😄 