### PR TITLE
Add country code RegExp with character from (k,m,b) abbreviations

### DIFF
--- a/src/components/utils/countryCodesWithAbbreviationsRegExp.ts
+++ b/src/components/utils/countryCodesWithAbbreviationsRegExp.ts
@@ -4,16 +4,16 @@
  * See: https://github.com/cchanxzy/react-currency-input-field/issues/279
  */
 export const countryCodesWithAbbreviationsChars = [
-    // with K
-    /[A-Z][A-Z]K/,
-    /[A-Z]K[A-Z]/,
-    /K[A-Z][A-Z]/,
-    // with M
-    /[A-Z][A-Z]M/,
-    /[A-Z]M[A-Z]/,
-    /M[A-Z][A-Z]/,
-    // with B
-    /[A-Z][A-Z]B/,
-    /[A-Z]B[A-Z]/,
-    /B[A-Z][A-Z]/,
-  ];
+  // with K
+  /[A-Z][A-Z]K/,
+  /[A-Z]K[A-Z]/,
+  /K[A-Z][A-Z]/,
+  // with M
+  /[A-Z][A-Z]M/,
+  /[A-Z]M[A-Z]/,
+  /M[A-Z][A-Z]/,
+  // with B
+  /[A-Z][A-Z]B/,
+  /[A-Z]B[A-Z]/,
+  /B[A-Z][A-Z]/,
+];

--- a/src/components/utils/countryCodesWithAbbreviationsRegExp.ts
+++ b/src/components/utils/countryCodesWithAbbreviationsRegExp.ts
@@ -1,0 +1,19 @@
+/**
+ * Country code with abbreviations chars regexp
+ *
+ * See: https://github.com/cchanxzy/react-currency-input-field/issues/279
+ */
+export const countryCodesWithAbbreviationsChars = [
+    // with K
+    /[A-Z][A-Z]K/,
+    /[A-Z]K[A-Z]/,
+    /K[A-Z][A-Z]/,
+    // with M
+    /[A-Z][A-Z]M/,
+    /[A-Z]M[A-Z]/,
+    /M[A-Z][A-Z]/,
+    // with B
+    /[A-Z][A-Z]B/,
+    /[A-Z]B[A-Z]/,
+    /B[A-Z][A-Z]/,
+  ];

--- a/src/components/utils/removeInvalidChars.ts
+++ b/src/components/utils/removeInvalidChars.ts
@@ -1,19 +1,5 @@
 import { escapeRegExp } from './escapeRegExp';
-
-const countryCodesWithAbbreviationsChars = [
-  // with K
-  /[A-Z][A-Z]K/,
-  /[A-Z]K[A-Z]/,
-  /K[A-Z][A-Z]/,
-  // with M
-  /[A-Z][A-Z]M/,
-  /[A-Z]M[A-Z]/,
-  /M[A-Z][A-Z]/,
-  // with B
-  /[A-Z][A-Z]B/,
-  /[A-Z]B[A-Z]/,
-  /B[A-Z][A-Z]/,
-];
+import {countryCodesWithAbbreviationsChars} from './countryCodesWithAbbreviationsRegExp'
 
 /**
  * Remove invalid characters

--- a/src/components/utils/removeInvalidChars.ts
+++ b/src/components/utils/removeInvalidChars.ts
@@ -1,5 +1,5 @@
 import { escapeRegExp } from './escapeRegExp';
-import {countryCodesWithAbbreviationsChars} from './countryCodesWithAbbreviationsRegExp'
+import { countryCodesWithAbbreviationsChars } from './countryCodesWithAbbreviationsRegExp';
 
 /**
  * Remove invalid characters

--- a/src/components/utils/removeInvalidChars.ts
+++ b/src/components/utils/removeInvalidChars.ts
@@ -1,10 +1,33 @@
 import { escapeRegExp } from './escapeRegExp';
 
+const countryCodesWithAbbreviationsChars = [
+  // with K
+  /[A-Z][A-Z]K/,
+  /[A-Z]K[A-Z]/,
+  /K[A-Z][A-Z]/,
+  // with M
+  /[A-Z][A-Z]M/,
+  /[A-Z]M[A-Z]/,
+  /M[A-Z][A-Z]/,
+  // with B
+  /[A-Z][A-Z]B/,
+  /[A-Z]B[A-Z]/,
+  /B[A-Z][A-Z]/,
+];
+
 /**
  * Remove invalid characters
  */
 export const removeInvalidChars = (value: string, validChars: ReadonlyArray<string>): string => {
   const chars = escapeRegExp(validChars.join(''));
+
   const reg = new RegExp(`[^\\d${chars}]`, 'gi');
-  return value.replace(reg, '');
+
+  let clearValue = value;
+
+  countryCodesWithAbbreviationsChars.forEach((regExp) => {
+    clearValue = clearValue.replace(regExp, '');
+  });
+
+  return clearValue.replace(reg, '');
 };


### PR DESCRIPTION
According to the issue from here https://github.com/cchanxzy/react-currency-input-field/issues/279 I fixed that case by adding extra regexp