### PR TITLE
Add support to pass Intl.NumberFormatOptions to override default behaviours of NumberFormat

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -97,7 +97,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       decimalSeparator,
       groupSeparator,
       allowDecimals,
-      decimalsLimit: decimalsLimit || fixedDecimalLength || 2,
+      decimalsLimit: options?.maximumFractionDigits || decimalsLimit || fixedDecimalLength || 2,
       allowNegativeValue,
       disableAbbreviations,
       prefix: prefix || localeConfig.prefix,
@@ -106,9 +106,9 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
 
     const formattedStateValue =
       defaultValue !== undefined && defaultValue !== null
-        ? formatValue({ ...formatValueOptions, decimalScale, value: String(defaultValue) })
+        ? formatValue({ ...formatValueOptions, decimalScale, value: String(defaultValue) }, options)
         : userValue !== undefined && userValue !== null
-        ? formatValue({ ...formatValueOptions, decimalScale, value: String(userValue) })
+        ? formatValue({ ...formatValueOptions, decimalScale, value: String(userValue) }, options)
         : '';
 
     const [stateValue, setStateValue] = useState(formattedStateValue);

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -58,6 +58,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       onKeyDown,
       onKeyUp,
       transformRawValue,
+      options,
       ...props
     }: CurrencyInputProps,
     ref
@@ -70,7 +71,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       throw new Error('groupSeparator cannot be a number');
     }
 
-    const localeConfig = useMemo(() => getLocaleConfig(intlConfig), [intlConfig]);
+    const localeConfig = useMemo(() => getLocaleConfig(intlConfig, options), [intlConfig]);
     const decimalSeparator = _decimalSeparator || localeConfig.decimalSeparator || '';
     const groupSeparator = _groupSeparator || localeConfig.groupSeparator || '';
 

--- a/src/components/CurrencyInputProps.ts
+++ b/src/components/CurrencyInputProps.ts
@@ -182,7 +182,7 @@ export type CurrencyInputProps = Overwrite<
     /**
      * Intl.NumberFormat options
      *
-     * Allows users to pass options to overr
+     * Allows users to pass options to override default formatting
      */
     options?: Intl.NumberFormatOptions;
 

--- a/src/components/CurrencyInputProps.ts
+++ b/src/components/CurrencyInputProps.ts
@@ -180,6 +180,13 @@ export type CurrencyInputProps = Overwrite<
     intlConfig?: IntlConfig;
 
     /**
+     * Intl.NumberFormat options
+     *
+     * Allows users to pass options to overr
+     */
+    options?: Intl.NumberFormatOptions;
+
+    /**
      * Transform the raw value form the input before parsing
      */
     transformRawValue?: (rawValue: string) => string;

--- a/src/components/utils/__tests__/getLocaleConfig.spec.ts
+++ b/src/components/utils/__tests__/getLocaleConfig.spec.ts
@@ -30,4 +30,19 @@ describe('getLocaleConfig', () => {
       suffix: '',
     });
   });
+
+  it('should override default locale config with options', () => {
+    expect(
+      getLocaleConfig(
+        { locale: 'ja-JP', currency: 'JPY' },
+        { maximumFractionDigits: 2, minimumSignificantDigits: 2 }
+      )
+    ).toStrictEqual({
+      currencySymbol: '￥',
+      decimalSeparator: '.',
+      groupSeparator: ',',
+      prefix: '￥',
+      suffix: '',
+    });
+  });
 });

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -57,7 +57,10 @@ export type FormatValueOptions = {
 /**
  * Format value with decimal separator, group separator and prefix
  */
-export const formatValue = (options: FormatValueOptions): string => {
+export const formatValue = (
+  options: FormatValueOptions,
+  numberFormatterOptions: Intl.NumberFormatOptions = {}
+): string => {
   const {
     value: _value,
     decimalSeparator,
@@ -87,6 +90,7 @@ export const formatValue = (options: FormatValueOptions): string => {
   const defaultNumberFormatOptions = {
     minimumFractionDigits: decimalScale || 0,
     maximumFractionDigits: 20,
+    ...numberFormatterOptions,
   };
 
   const numberFormatter = intlConfig

--- a/src/components/utils/getLocaleConfig.ts
+++ b/src/components/utils/getLocaleConfig.ts
@@ -19,10 +19,16 @@ const defaultConfig: LocaleConfig = {
 /**
  * Get locale config from input or default
  */
-export const getLocaleConfig = (intlConfig?: IntlConfig): LocaleConfig => {
+export const getLocaleConfig = (
+  intlConfig?: IntlConfig,
+  options?: Intl.NumberFormatOptions
+): LocaleConfig => {
   const { locale, currency } = intlConfig || {};
   const numberFormatter = locale
-    ? new Intl.NumberFormat(locale, currency ? { currency, style: 'currency' } : undefined)
+    ? new Intl.NumberFormat(
+        locale,
+        currency ? { ...options, currency, style: 'currency' } : { ...options }
+      )
     : new Intl.NumberFormat();
 
   return numberFormatter.formatToParts(1000.1).reduce((prev, curr, i): LocaleConfig => {


### PR DESCRIPTION
As `decimalsLimit` would not override the `maximumFractionDigits` digits and currency like Yen it is zero it's impossible to change it and have fractional digit support. 

This PR allows the user to pass `Intl.NumberFormatOptions` to pass it `<CurrencyInput />` such that users can pass it.