### PR TITLE
#286: Invalid multiplication abbreviation value

### DIFF
--- a/src/components/utils/cleanValue.ts
+++ b/src/components/utils/cleanValue.ts
@@ -58,8 +58,11 @@ export const cleanValue = ({
 
   if (!disableAbbreviations) {
     // disallow letter without number
-    if (abbreviations.some((letter) => letter === withoutInvalidChars.toLowerCase())) {
-      return '';
+    if (
+      abbreviations.some(
+        (letter) => letter === withoutInvalidChars.toLowerCase().replace(decimalSeparator, '')
+      )
+    ) {      return '';
     }
     const parsed = parseAbbrValue(withoutInvalidChars, decimalSeparator);
     if (parsed) {


### PR DESCRIPTION
Fix for [issue #286](https://github.com/cchanxzy/react-currency-input-field/issues/286)

**Problem:** If you type a period (or whatever character you have set as the decimal separator) and then press a multiplier abbreviation (k,m,b) then  the input will display as NaN. This is because when the `cleanValue` util is filtering out single letters entered without a number, the `removeInvalidChars` method isn't excluding the decimal separator.

**Solution:** Remove any decimal separators when checking for invalid abbreviations.