### PR TITLE
Fix decimal separator issues

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -209,7 +209,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
 
       const valueOnly = cleanValue({ value, ...cleanValueOptions });
 
-      if (valueOnly === '-' || !valueOnly) {
+      if (valueOnly === '-' || valueOnly === decimalSeparator || !valueOnly) {
         setStateValue('');
         onBlur && onBlur(event);
         return;

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -141,6 +141,8 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       if (stringValue === '' || stringValue === '-' || stringValue === decimalSeparator) {
         onValueChange && onValueChange(undefined, name, { float: null, formatted: '', value: '' });
         setStateValue(stringValue);
+        // Always sets cursor after '-' or decimalSeparator input
+        setCursor(1);
         return;
       }
 

--- a/src/components/__tests__/CurrencyInput.spec.tsx
+++ b/src/components/__tests__/CurrencyInput.spec.tsx
@@ -204,6 +204,20 @@ describe('<CurrencyInput/>', () => {
     expect(screen.getByRole('textbox')).toHaveValue('');
   });
 
+  it('should allow .3 decimal inputs', () => {
+    render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '.3');
+
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('.3', undefined, {
+      float: 0.3,
+      formatted: '£0.3',
+      value: '.3',
+    });
+
+    fireEvent.focusOut(screen.getByRole('textbox'));
+    expect(screen.getByRole('textbox')).toHaveValue('£0.3');
+  });
+
   it('should call onChange', () => {
     const onChangeSpy = jest.fn();
     render(<CurrencyInput prefix="£" onChange={onChangeSpy} />);

--- a/src/components/__tests__/CurrencyInput.spec.tsx
+++ b/src/components/__tests__/CurrencyInput.spec.tsx
@@ -190,6 +190,20 @@ describe('<CurrencyInput/>', () => {
     expect(screen.getByRole('textbox')).toHaveValue('£123');
   });
 
+  it('should clear decimal point only input', () => {
+    render(<CurrencyInput prefix="£" onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '.');
+
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith(undefined, undefined, {
+      float: null,
+      formatted: '',
+      value: '',
+    });
+
+    fireEvent.focusOut(screen.getByRole('textbox'));
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
   it('should call onChange', () => {
     const onChangeSpy = jest.fn();
     render(<CurrencyInput prefix="£" onChange={onChangeSpy} />);

--- a/src/components/utils/__tests__/cleanValue.spec.ts
+++ b/src/components/utils/__tests__/cleanValue.spec.ts
@@ -209,21 +209,21 @@ describe('cleanValue', () => {
       expect(
         cleanValue({
           value: 'k',
-          disableAbbreviations: true,
+          disableAbbreviations: false,
         })
       ).toEqual('');
 
       expect(
         cleanValue({
           value: 'm',
-          disableAbbreviations: true,
+          disableAbbreviations: false,
         })
       ).toEqual('');
 
       expect(
         cleanValue({
           value: 'b',
-          disableAbbreviations: true,
+          disableAbbreviations: false,
         })
       ).toEqual('');
     });
@@ -233,7 +233,7 @@ describe('cleanValue', () => {
         cleanValue({
           value: '$k',
           prefix: '$',
-          disableAbbreviations: true,
+          disableAbbreviations: false,
         })
       ).toEqual('');
 
@@ -241,7 +241,28 @@ describe('cleanValue', () => {
         cleanValue({
           value: '£m',
           prefix: '£',
-          disableAbbreviations: true,
+          disableAbbreviations: false,
+        })
+      ).toEqual('');
+    });
+
+    it('should return empty string if decimal separator and abbreviation only', () => {
+      expect(
+        cleanValue({
+          value: '.k',
+        })
+      ).toEqual('');
+
+      expect(
+        cleanValue({
+          value: '.m',
+        })
+      ).toEqual('');
+
+      expect(
+        cleanValue({
+          value: '£.m',
+          prefix: '£',
         })
       ).toEqual('');
     });

--- a/src/components/utils/cleanValue.ts
+++ b/src/components/utils/cleanValue.ts
@@ -58,7 +58,11 @@ export const cleanValue = ({
 
   if (!disableAbbreviations) {
     // disallow letter without number
-    if (abbreviations.some((letter) => letter === withoutInvalidChars.toLowerCase())) {
+    if (
+      abbreviations.some(
+        (letter) => letter === withoutInvalidChars.toLowerCase().replace(decimalSeparator, '')
+      )
+    ) {
       return '';
     }
     const parsed = parseAbbrValue(withoutInvalidChars, decimalSeparator);


### PR DESCRIPTION
Fixes https://github.com/cchanxzy/react-currency-input-field/issues/293, https://github.com/cchanxzy/react-currency-input-field/issues/286, and single decimal point inputs. See original issues for how to reproduce.

Single decimal point repro:

1. In [Example 1](https://cchanxzy.github.io/react-currency-input-field/), type `.` (can be reproduced in any other input that accepts `.` or `,` decimal separators, e.g. Example 3 with `,` input);
2. Move focus outside input;
3. Results in `"formatted": "£NaN.", "value": "."` values;
4. Expected `"formatted": "", "value": ""`;
