### PR TITLE
fix: fixedDecimalValue issue #292 and handle fixedDecimalValue 0

### DIFF
--- a/src/components/utils/__tests__/fixedDecimalValue.spec.ts
+++ b/src/components/utils/__tests__/fixedDecimalValue.spec.ts
@@ -5,12 +5,22 @@ describe('fixedDecimalValue', () => {
     expect(fixedDecimalValue('abc', '.', 2)).toEqual('abc');
   });
 
+  it('should work with 0 fixed decimal length', () => {
+    expect(fixedDecimalValue('123', '.', 0)).toEqual('123');
+    expect(fixedDecimalValue('1.23', '.', 0)).toEqual('123');
+    expect(fixedDecimalValue('123,45', ',', 0)).toEqual('12345');
+  });
+
   it('should work with 2 fixed decimal length', () => {
     expect(fixedDecimalValue('1', '.', 2)).toEqual('1');
     expect(fixedDecimalValue('12', '.', 2)).toEqual('1.2');
     expect(fixedDecimalValue('123', '.', 2)).toEqual('1.23');
     expect(fixedDecimalValue('12345', '.', 2)).toEqual('123.45');
     expect(fixedDecimalValue('123.4567', '.', 2)).toEqual('123.45');
+
+    expect(fixedDecimalValue('1111.11', '.', 2)).toEqual('1111.11');
+    expect(fixedDecimalValue('1111.111', '.', 2)).toEqual('1111.11');
+    expect(fixedDecimalValue('2222.33 ', '.', 2)).toEqual('2222.33');
   });
 
   it('should work with 4 fixed decimal length', () => {

--- a/src/components/utils/fixedDecimalValue.ts
+++ b/src/components/utils/fixedDecimalValue.ts
@@ -3,9 +3,18 @@ export const fixedDecimalValue = (
   decimalSeparator: string,
   fixedDecimalLength?: number
 ): string => {
-  if (fixedDecimalLength && value.length > 1) {
+  if (fixedDecimalLength !== undefined && value.length > 1) {
+    if (fixedDecimalLength === 0) {
+      return value.replace(decimalSeparator, '');
+    }
+
     if (value.includes(decimalSeparator)) {
       const [int, decimals] = value.split(decimalSeparator);
+
+      if (decimals.length === fixedDecimalLength) {
+        return value;
+      }
+
       if (decimals.length > fixedDecimalLength) {
         return `${int}${decimalSeparator}${decimals.slice(0, fixedDecimalLength)}`;
       }


### PR DESCRIPTION
Fixes issue #292 regarding `fixedDecimalValue`.

Also, fixes/better handles if `fixedDecimalValue = 0` . Prior to this fix, `0` would be ignored, which isn't exactly correct. 
