### PR TITLE
fix: formatToParts in early Safari versions #320

### DIFF
--- a/src/components/utils/__tests__/getLocaleConfig.spec.ts
+++ b/src/components/utils/__tests__/getLocaleConfig.spec.ts
@@ -30,4 +30,24 @@ describe('getLocaleConfig', () => {
       suffix: '',
     });
   });
+
+  describe('with formatToParts missing', () => {
+    beforeEach(() => {
+      jest.spyOn(Intl, 'NumberFormat').mockImplementation();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return fallback en-US config', () => {
+      expect(getLocaleConfig()).toStrictEqual({
+        currencySymbol: '',
+        decimalSeparator: '.',
+        groupSeparator: ',',
+        prefix: '',
+        suffix: '',
+      });
+    });
+  })
 });

--- a/src/components/utils/getLocaleConfig.ts
+++ b/src/components/utils/getLocaleConfig.ts
@@ -16,6 +16,14 @@ const defaultConfig: LocaleConfig = {
   suffix: '',
 };
 
+const fallbackConfig: LocaleConfig = {
+  currencySymbol: '',
+  groupSeparator: ',',
+  decimalSeparator: '.',
+  prefix: '',
+  suffix: '',
+};
+
 /**
  * Get locale config from input or default
  */
@@ -24,6 +32,10 @@ export const getLocaleConfig = (intlConfig?: IntlConfig): LocaleConfig => {
   const numberFormatter = locale
     ? new Intl.NumberFormat(locale, currency ? { currency, style: 'currency' } : undefined)
     : new Intl.NumberFormat();
+
+  if (typeof numberFormatter.formatToParts !== 'function') {
+    return fallbackConfig;
+  }
 
   return numberFormatter.formatToParts(1000.1).reduce((prev, curr, i): LocaleConfig => {
     if (curr.type === 'currency') {


### PR DESCRIPTION
Fixes issue #320 regarding formatToParts in Safari versions < 13.