### PR TITLE
fix: Update input to empty string when `userValue` is `undefined`

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -103,14 +103,13 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       transformRawValue,
     };
 
-    const formattedStateValue =
+    const [stateValue, setStateValue] = useState(() =>
       defaultValue != null
         ? formatValue({ ...formatValueOptions, decimalScale, value: String(defaultValue) })
         : userValue != null
         ? formatValue({ ...formatValueOptions, decimalScale, value: String(userValue) })
-        : '';
-
-    const [stateValue, setStateValue] = useState(formattedStateValue);
+        : ''
+    );
     const [dirty, setDirty] = useState(false);
     const [cursor, setCursor] = useState(0);
     const [changeCount, setChangeCount] = useState(0);

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -314,6 +314,13 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       onKeyUp && onKeyUp(event);
     };
 
+    // Update state if userValue changes to undefined
+    useEffect(() => {
+      if (userValue == null && defaultValue == null) {
+        setStateValue('');
+      }
+    }, [userValue]);
+
     useEffect(() => {
       // prevent cursor jumping if editing value
       if (

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -319,7 +319,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       if (userValue == null && defaultValue == null) {
         setStateValue('');
       }
-    }, [userValue]);
+    }, [defaultValue, userValue]);
 
     useEffect(() => {
       // prevent cursor jumping if editing value

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -104,9 +104,9 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
     };
 
     const formattedStateValue =
-      defaultValue !== undefined && defaultValue !== null
+      defaultValue != null
         ? formatValue({ ...formatValueOptions, decimalScale, value: String(defaultValue) })
-        : userValue !== undefined && userValue !== null
+        : userValue != null
         ? formatValue({ ...formatValueOptions, decimalScale, value: String(userValue) })
         : '';
 
@@ -157,7 +157,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
         ...formatValueOptions,
       });
 
-      if (cursorPosition !== undefined && cursorPosition !== null) {
+      if (cursorPosition != null) {
         // Prevent cursor jumping
         let newCursor = cursorPosition + (formattedValue.length - value.length);
         newCursor = newCursor <= 0 ? (prefix ? prefix.length : 0) : newCursor;
@@ -261,7 +261,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
 
         const currentValue =
           parseFloat(
-            userValue !== undefined && userValue !== null
+            userValue != null
               ? String(userValue).replace(decimalSeparator, '.')
               : cleanValue({ value: stateValue, ...cleanValueOptions })
           ) || 0;
@@ -333,8 +333,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
      */
     const getRenderValue = () => {
       if (
-        userValue !== undefined &&
-        userValue !== null &&
+        userValue != null &&
         stateValue !== '-' &&
         (!decimalSeparator || stateValue !== decimalSeparator)
       ) {

--- a/src/components/__tests__/CurrencyInput.spec.tsx
+++ b/src/components/__tests__/CurrencyInput.spec.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React from 'react';
 import '@testing-library/jest-dom';
 import { render, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/src/components/__tests__/CurrencyInput.spec.tsx
+++ b/src/components/__tests__/CurrencyInput.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import '@testing-library/jest-dom';
 import { render, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -260,4 +260,33 @@ describe('<CurrencyInput/>', () => {
 
     expect(onKeyUpSpy).toBeCalledTimes(1);
   });
+
+  it('should blank the input when prop value changes from a number to undefined', () => {
+    render(<TestCurrencyInput initValue={'1'} />);
+
+    const field = screen.getByRole('textbox');
+    expect(field).toHaveValue('£1');
+
+    // Click the reset button
+    const resetButton = screen.getByRole('button');
+    userEvent.click(resetButton);
+
+    expect(field).toHaveValue('');
+  });
 });
+
+// Test component that holds the state of the input value.
+const TestCurrencyInput: FC<{ initValue?: string }> = (prop) => {
+  const [value, setValue] = React.useState<string | undefined>(prop.initValue);
+  return (
+    <div>
+      <CurrencyInput
+        value={value}
+        onValueChange={(v) => setValue(v)}
+        placeholder="Please enter a number"
+        prefix="£"
+      />
+      <button onClick={() => setValue(undefined)}>Reset</button>
+    </div>
+  );
+};

--- a/src/components/__tests__/CurrencyInput.spec.tsx
+++ b/src/components/__tests__/CurrencyInput.spec.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import { render, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CurrencyInput from '../CurrencyInput';
+import { act } from 'react-dom/test-utils';
 
 describe('<CurrencyInput/>', () => {
   const onValueChangeSpy = jest.fn();
@@ -261,32 +262,33 @@ describe('<CurrencyInput/>', () => {
     expect(onKeyUpSpy).toBeCalledTimes(1);
   });
 
-  it('should blank the input when prop value changes from a number to undefined', () => {
-    render(<TestCurrencyInput initValue={'1'} />);
+  it('should update the input when prop value changes to another number', () => {
+    const { rerender } = render(
+      <CurrencyInput value="1" placeholder="Please enter a number" prefix="£" />
+    );
 
     const field = screen.getByRole('textbox');
     expect(field).toHaveValue('£1');
 
-    // Click the reset button
-    const resetButton = screen.getByRole('button');
-    userEvent.click(resetButton);
+    act(() => {
+      rerender(<CurrencyInput value="2" placeholder="Please enter a number" prefix="£" />);
+    });
+
+    expect(field).toHaveValue('£2');
+  });
+
+  it('should update the input when prop value changes to undefined', () => {
+    const { rerender } = render(
+      <CurrencyInput value="1" placeholder="Please enter a number" prefix="£" />
+    );
+
+    const field = screen.getByRole('textbox');
+    expect(field).toHaveValue('£1');
+
+    act(() => {
+      rerender(<CurrencyInput value={undefined} placeholder="Please enter a number" prefix="£" />);
+    });
 
     expect(field).toHaveValue('');
   });
 });
-
-// Test component that holds the state of the input value.
-const TestCurrencyInput: FC<{ initValue?: string }> = (prop) => {
-  const [value, setValue] = React.useState<string | undefined>(prop.initValue);
-  return (
-    <div>
-      <CurrencyInput
-        value={value}
-        onValueChange={(v) => setValue(v)}
-        placeholder="Please enter a number"
-        prefix="£"
-      />
-      <button onClick={() => setValue(undefined)}>Reset</button>
-    </div>
-  );
-};

--- a/src/components/__tests__/CurrencyInput.spec.tsx
+++ b/src/components/__tests__/CurrencyInput.spec.tsx
@@ -278,15 +278,13 @@ describe('<CurrencyInput/>', () => {
   });
 
   it('should update the input when prop value changes to undefined', () => {
-    const { rerender } = render(
-      <CurrencyInput value="1" placeholder="Please enter a number" prefix="£" />
-    );
+    const { rerender } = render(<CurrencyInput value="1" prefix="£" />);
 
     const field = screen.getByRole('textbox');
     expect(field).toHaveValue('£1');
 
     act(() => {
-      rerender(<CurrencyInput value={undefined} placeholder="Please enter a number" prefix="£" />);
+      rerender(<CurrencyInput value={undefined} prefix="£" />);
     });
 
     expect(field).toHaveValue('');


### PR DESCRIPTION
Fixes #322.

I'm unsure if that's the correct approach, but all tests pass, including the ones I added that weren't passing before the fix.