### PR TITLE
fix: #299 Inconsistent user experience when entering '.' as the first character

### DIFF
--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -84,7 +84,7 @@ export const formatValue = (options: FormatValueOptions): string => {
       ? replaceDecimalSeparator(_value, decimalSeparator, isNegative)
       : _value;
 
-  if (value.startsWith(decimalSeparator)) {
+  if (decimalSeparator && value.startsWith(decimalSeparator)) {
     value = '0' + value;
   }
 

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -79,10 +79,14 @@ export const formatValue = (options: FormatValueOptions): string => {
     _value
   );
 
-  const value =
+  let value =
     decimalSeparator !== '.'
       ? replaceDecimalSeparator(_value, decimalSeparator, isNegative)
       : _value;
+
+  if (decimalSeparator === ".") {
+    value = '0' + value;
+  }
 
   const defaultNumberFormatOptions = {
     minimumFractionDigits: decimalScale || 0,

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -84,7 +84,7 @@ export const formatValue = (options: FormatValueOptions): string => {
       ? replaceDecimalSeparator(_value, decimalSeparator, isNegative)
       : _value;
 
-  if (decimalSeparator === ".") {
+  if (value.startsWith(decimalSeparator)) {
     value = '0' + value;
   }
 


### PR DESCRIPTION
## TICKET

https://github.com/cchanxzy/react-currency-input-field/issues/299

## CHANGELOG

- [x] Add condition to add "0" incase "." is entered