### PR TITLE
fix: clean negative decimal seperator (#336)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/src/components/utils/__tests__/cleanValue.spec.ts
+++ b/src/components/utils/__tests__/cleanValue.spec.ts
@@ -132,6 +132,19 @@ describe('cleanValue', () => {
       ).toEqual('-123');
     });
 
+    it('should handle negative value with decimal seperator', () => {
+      expect(
+        cleanValue({
+          value: '-.',
+          decimalSeparator: '.',
+          groupSeparator: ',',
+          allowDecimals: true,
+          decimalsLimit: 2,
+          prefix: '£',
+        })
+      ).toEqual('-0.');
+    });
+
     it('should handle negative value with decimal', () => {
       expect(
         cleanValue({

--- a/src/components/utils/cleanValue.ts
+++ b/src/components/utils/cleanValue.ts
@@ -36,6 +36,10 @@ export const cleanValue = ({
     return transformedValue;
   }
 
+  if (transformedValue === '-.') {
+    return '-0.';
+  }
+
   const abbreviations = disableAbbreviations ? [] : ['k', 'm', 'b'];
   const reg = new RegExp(`((^|\\D)-\\d)|(-${escapeRegExp(prefix)})`);
   const isNegative = reg.test(transformedValue);


### PR DESCRIPTION
Entering "-." gets immediately changed into "." have been fixed and now changes to "-0."