### PR TITLE
Issue #299 : Handle decimal values starting with ' . '

### DIFF
--- a/src/components/utils/__tests__/formatValue.spec.ts
+++ b/src/components/utils/__tests__/formatValue.spec.ts
@@ -203,6 +203,18 @@ describe('formatValue', () => {
     ).toEqual('$30');
   });
 
+  it('should prefix decimal values correctly with zero', () => {
+    expect(
+      formatValue({
+        decimalSeparator: '.',
+        groupSeparator: ',',
+        decimalScale: 2,
+        prefix: '$',
+        value: '.02',
+      })
+    ).toEqual('$0.02');
+  });
+
   describe('negative values', () => {
     it('should handle negative values', () => {
       expect(

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -79,10 +79,14 @@ export const formatValue = (options: FormatValueOptions): string => {
     _value
   );
 
-  const value =
+  let value =
     decimalSeparator !== '.'
       ? replaceDecimalSeparator(_value, decimalSeparator, isNegative)
       : _value;
+
+  if (value.startsWith('.')) {
+    value = '0' + value;
+  }
 
   const defaultNumberFormatOptions = {
     minimumFractionDigits: decimalScale || 0,

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -84,7 +84,7 @@ export const formatValue = (options: FormatValueOptions): string => {
       ? replaceDecimalSeparator(_value, decimalSeparator, isNegative)
       : _value;
 
-  if (value.startsWith('.')) {
+  if (decimalSeparator && decimalSeparator !== '-' && value.startsWith(decimalSeparator)) {
     value = '0' + value;
   }
 


### PR DESCRIPTION
Issue https://github.com/cchanxzy/react-currency-input-field/issues/299

- This fix is specifically targeted to handle decimal input when ' . ' is entered. 
- Added neccessary tests.
- Tests are passing locally.

Built and tested.