### PR TITLE
export getLocaleConfig and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
     - [Decimal Scale and Decimals Limit](#decimal-scale-and-decimals-limit)
     - [Fixed Decimal Length](#fixed-decimal-length)
   - [Format values for display](#format-values-for-display)
+  - [Clean values](#clean-values)
+  - [Get locale configuration](#get-locale-configuration)
   - [v3.0.0 Release Notes](#v300-release-notes)
     - [Breaking Changes](#breaking-changes)
     - [Improvements in v3](#improvements-in-v3)
@@ -250,6 +252,50 @@ const formattedValue2 = formatValue({
 
 console.log(formattedValue2);
 // ₹5,00,000
+```
+
+## Clean values
+
+Use the `cleanValue` function to remove the prefix, suffix and separators from the value, and return the raw float value.
+
+```javascript
+import { cleanValue } from 'react-currency-input-field';
+
+const cleanedValue = cleanValue({
+  value: '$1,000.25',
+  prefix: '$',
+  groupSeparator: ',',
+  decimalSeparator: '.',
+  allowNegativeValue: true,
+  allowDecimals: true,
+  decimalsLimit: 2,
+  disableAbbreviations: false,
+  transformRawValue: (rawValue) => rawValue,
+});
+
+console.log(cleanedValue);
+// 1000.25
+```
+
+## Get locale configuration
+
+Use the `getLocaleConfig` function to get the locale configuration for a given locale and currency.
+
+```javascript
+import { getLocaleConfig } from 'react-currency-input-field';
+
+type LocaleConfig = {
+  currencySymbol: string;
+  groupSeparator: string;
+  decimalSeparator: string;
+  prefix: string;
+  suffix: string;
+};
+
+const localeConfig: LocaleConfig = getLocaleConfig({ locale: 'en-US', currency: 'USD' });
+
+console.log(localeConfig);
+// { currencySymbol: '$', groupSeparator: ',', decimalSeparator: '.', prefix: '', suffix: '' }
 ```
 
 ## v3.0.0 Release Notes

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Have a look in [`src/examples`](https://github.com/cchanxzy/react-currency-input
 | maxLength                                          | `number`   |                | Maximum characters the user can enter                                                          |
 | step                                               | `number`   |                | Incremental value change on arrow down and arrow up key press                                  |
 | transformRawValue                                  | `function` |                | Transform the raw value from the input before parsing. Needs to return `string`.               |
-| formatValueOnBlur                                  | `function` | `true`         | Allows users to customize the behavior of the onValueChange function on blur events. Default's to `true`. When `false` onBlur events will not trigger onValueChange.               |
+| formatValueOnBlur                                  | `boolean`  | `true`         | Allows users to customize the behavior of the onValueChange function on blur events. Default's to `true`. When `false` onBlur events will not trigger onValueChange.               |
 
 ### onValueChange
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Have a look in [`src/examples`](https://github.com/cchanxzy/react-currency-input
 | maxLength                                          | `number`   |                | Maximum characters the user can enter                                                          |
 | step                                               | `number`   |                | Incremental value change on arrow down and arrow up key press                                  |
 | transformRawValue                                  | `function` |                | Transform the raw value from the input before parsing. Needs to return `string`.               |
+| formatValueOnBlur                                  | `function` | `true`         | Allows users to customize the behavior of the onValueChange function on blur events. Default's to `true`. When `false` onBlur events will not trigger onValueChange.               |
 
 ### onValueChange
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export { CurrencyInputProps, CurrencyInputOnChangeValues } from './components/Cu
 export default CurrencyInput;
 export { formatValue } from './components/utils/formatValue';
 export { cleanValue } from './components/utils/cleanValue';
+export { getLocaleConfig } from './components/utils/getLocaleConfig';


### PR DESCRIPTION
# Problem

`cleanValue` asks for values that are quite hard to get, but those are easily obtainable with the already done function `getLocaleConfig`.

# Solution

Export the getLocaleConfig as part of the package, plus add it to the docs.

# Additional changes

- Added `cleanValue` to the README.md
- Added `formatValueOnBlur` to the README.md since it was missing.