### PR TITLE
feat(types): export `IntlConfig` type from root entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import CurrencyInput from './components/CurrencyInput';
 
-export { CurrencyInputProps, CurrencyInputOnChangeValues } from './components/CurrencyInputProps';
+export { CurrencyInputProps, CurrencyInputOnChangeValues, IntlConfig } from './components/CurrencyInputProps';
 export default CurrencyInput;
 export { formatValue } from './components/utils/formatValue';
 export { cleanValue } from './components/utils/cleanValue';


### PR DESCRIPTION
We forgot to export the `IntlConfig` props, resulting longer code when importing this type:
```ts
import type { IntlConfig } from 'react-currency-input-field/dist/components/CurrencyInputProps'
```

This changes adjust it so that user will no longer import the types from deep folder
```ts
import CurrencyInput, { type IntlConfig } from 'react-currency-input-field'
```