### PR TITLE
fix: handle cases where decimalSeparator is empty

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -108,8 +108,8 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       defaultValue != null
         ? formatValue({ ...formatValueOptions, decimalScale, value: String(defaultValue) })
         : userValue != null
-        ? formatValue({ ...formatValueOptions, decimalScale, value: String(userValue) })
-        : ''
+          ? formatValue({ ...formatValueOptions, decimalScale, value: String(userValue) })
+          : ''
     );
     const [dirty, setDirty] = useState(false);
     const [cursor, setCursor] = useState(0);
@@ -225,7 +225,11 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
         decimalScale !== undefined ? decimalScale : fixedDecimalLength
       );
 
-      const numberValue = parseFloat(newValue.replace(decimalSeparator, '.'));
+      const stringValueWithoutSeparator = decimalSeparator
+        ? newValue.replace(decimalSeparator, '.')
+        : newValue;
+
+      const numberValue = parseFloat(stringValueWithoutSeparator);
 
       const formattedValue = formatValue({
         ...formatValueOptions,
@@ -259,10 +263,16 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
         event.preventDefault();
         setCursor(stateValue.length);
 
+        const stringValue = userValue != null ? String(userValue) : undefined;
+        const stringValueWithoutSeparator =
+          decimalSeparator && stringValue
+            ? stringValue.replace(decimalSeparator, '.')
+            : stringValue;
+
         const currentValue =
           parseFloat(
-            userValue != null
-              ? String(userValue).replace(decimalSeparator, '.')
+            stringValueWithoutSeparator != null
+              ? stringValueWithoutSeparator
               : cleanValue({ value: stateValue, ...cleanValueOptions })
           ) || 0;
         const newValue = key === 'ArrowUp' ? currentValue + step : currentValue - step;

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -277,7 +277,10 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
           ) || 0;
         const newValue = key === 'ArrowUp' ? currentValue + step : currentValue - step;
 
-        if (min !== undefined && newValue < Number(min)) {
+        if (
+          (min !== undefined && newValue < Number(min)) ||
+          (!allowNegativeValue && newValue < 0)
+        ) {
           return;
         }
 

--- a/src/components/__tests__/CurrencyInput-decimals.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-decimals.spec.tsx
@@ -100,6 +100,28 @@ describe('<CurrencyInput/> decimals', () => {
     });
   });
 
+  it('should handle currencies without decimals with provided decimalScale', () => {
+    render(
+      <CurrencyInput
+        decimalScale={0}
+        intlConfig={{ locale: 'ja-JP', currency: 'JPY' }}
+        onValueChange={onValueChangeSpy}
+      />
+    );
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+
+    userEvent.type(screen.getByRole('textbox'), '123');
+    userEvent.click(document.body);
+
+    expect(screen.getByRole('textbox')).toHaveValue('￥123');
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('123', undefined, {
+      float: 123,
+      formatted: '￥123',
+      value: '123',
+    });
+  });
+
   it('should handle starting with decimal separator that is non period', () => {
     render(
       <CurrencyInput

--- a/src/components/utils/__tests__/padTrimValue.spec.ts
+++ b/src/components/utils/__tests__/padTrimValue.spec.ts
@@ -29,4 +29,9 @@ describe('padTrimValue', () => {
   it('should trim handle comma as decimal separator', () => {
     expect(padTrimValue('9,9', ',', 3)).toEqual('9,900');
   });
+
+  it('should trim handle empty decimal separator', () => {
+    expect(padTrimValue('99', '', 0)).toEqual('99');
+    expect(padTrimValue('99', '')).toEqual('99');
+  });
 });

--- a/src/components/utils/padTrimValue.ts
+++ b/src/components/utils/padTrimValue.ts
@@ -3,7 +3,12 @@ export const padTrimValue = (
   decimalSeparator = '.',
   decimalScale?: number
 ): string => {
-  if (decimalScale === undefined || value === '' || value === undefined) {
+  if (
+    decimalScale === undefined ||
+    decimalSeparator === '' ||
+    value === '' ||
+    value === undefined
+  ) {
     return value;
   }
 

--- a/src/components/utils/padTrimValue.ts
+++ b/src/components/utils/padTrimValue.ts
@@ -1,11 +1,12 @@
 export const padTrimValue = (
   value: string,
-  decimalSeparator = '.',
+  decimalSeparator?: string,
   decimalScale?: number
 ): string => {
   if (
     decimalScale === undefined ||
     decimalSeparator === '' ||
+    decimalSeparator === undefined ||
     value === '' ||
     value === undefined
   ) {


### PR DESCRIPTION
Previously, for zero-decimal currencies (such as JPY), input will be lost on blur if `decimalScale` is used (no matter what value was passed in). This was down to the fact that `decimalSeparator` from `getLocaleConfig` will be `undefined` (since it doesn't exist in the output of `formatToParts`), and the fallback value of `''` was used.

This PR adds handling in the pad/trim logic to skip all processing when we see `''` as the separator.

Fixes #310