### PR TITLE
feat: intlConfig support all NumberFormatOptions

### DIFF
--- a/src/components/CurrencyInputProps.ts
+++ b/src/components/CurrencyInputProps.ts
@@ -32,8 +32,7 @@ export type CurrencyInputOnChangeValues = {
 
 export type IntlConfig = {
   locale: string;
-  currency?: string;
-};
+} & Intl.NumberFormatOptions;
 
 export type CurrencyInputProps = Overwrite<
   React.ComponentPropsWithRef<'input'>,
@@ -189,6 +188,6 @@ export type CurrencyInputProps = Overwrite<
      * specifically on blur events. If disabled or set to false, the onValueChange will not trigger on blur.
      * Default = true
      */
-     formatValueOnBlur?: boolean;
+    formatValueOnBlur?: boolean;
   }
 >;

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -88,22 +88,19 @@ export const formatValue = (options: FormatValueOptions): string => {
     value = '0' + value;
   }
 
+  const { locale, currency, ...formatOptions } = intlConfig || {};
+
   const defaultNumberFormatOptions = {
+    ...formatOptions,
     minimumFractionDigits: decimalScale || 0,
     maximumFractionDigits: 20,
   };
 
   const numberFormatter = intlConfig
-    ? new Intl.NumberFormat(
-        intlConfig.locale,
-        intlConfig.currency
-          ? {
-              ...defaultNumberFormatOptions,
-              style: 'currency',
-              currency: intlConfig.currency,
-            }
-          : defaultNumberFormatOptions
-      )
+    ? new Intl.NumberFormat(locale, {
+        ...defaultNumberFormatOptions,
+        ...(currency && { style: 'currency', currency }),
+      })
     : new Intl.NumberFormat(undefined, defaultNumberFormatOptions);
 
   const parts = numberFormatter.formatToParts(Number(value));

--- a/src/components/utils/getLocaleConfig.ts
+++ b/src/components/utils/getLocaleConfig.ts
@@ -20,9 +20,12 @@ const defaultConfig: LocaleConfig = {
  * Get locale config from input or default
  */
 export const getLocaleConfig = (intlConfig?: IntlConfig): LocaleConfig => {
-  const { locale, currency } = intlConfig || {};
+  const { locale, currency, ...formatOptions } = intlConfig || {};
   const numberFormatter = locale
-    ? new Intl.NumberFormat(locale, currency ? { currency, style: 'currency' } : undefined)
+    ? new Intl.NumberFormat(locale, {
+        ...formatOptions,
+        ...(currency && { currency, style: 'currency' }),
+      })
     : new Intl.NumberFormat();
 
   return numberFormatter.formatToParts(1000.1).reduce((prev, curr, i): LocaleConfig => {


### PR DESCRIPTION
`intlConfig` currently only exposes `locale` and `currency`.

This PR adds full support for [`Intl.NumberFormatOptions`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat).

Fixes #253 
Passing `{ useGrouping: true }` fixes #356 