### PR TITLE
Support setting prefix to an empty string

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -89,7 +89,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       groupSeparator,
       disableGroupSeparators,
       intlConfig,
-      prefix: prefix || localeConfig.prefix,
+      prefix: prefix ?? localeConfig.prefix,
       suffix: suffix,
     };
 
@@ -100,7 +100,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = forwardRef<
       decimalsLimit: decimalsLimit || fixedDecimalLength || 2,
       allowNegativeValue,
       disableAbbreviations,
-      prefix: prefix || localeConfig.prefix,
+      prefix: prefix ?? localeConfig.prefix,
       transformRawValue,
     };
 

--- a/src/components/__tests__/CurrencyInput-suffix.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-suffix.spec.tsx
@@ -44,4 +44,41 @@ describe('<CurrencyInput/> suffix', () => {
 
     expect(screen.getByRole('textbox')).toHaveValue('$1,234.9 %');
   });
+
+  it('should handle empty prefix and suffix', () => {
+    render(
+      <CurrencyInput onValueChange={onValueChangeSpy} prefix="" suffix="" defaultValue="1234" />
+    );
+
+    expect(screen.getByRole('textbox')).toHaveValue('1,234');
+
+    userEvent.type(screen.getByRole('textbox'), '56');
+
+    expect(screen.getByRole('textbox')).toHaveValue('123,456');
+
+    userEvent.type(screen.getByRole('textbox'), '{backspace}{backspace}');
+
+    expect(screen.getByRole('textbox')).toHaveValue('1,234');
+  });
+
+  it('should fallback to default prefix and suffix when undefined', () => {
+    render(
+      <CurrencyInput
+        onValueChange={onValueChangeSpy}
+        prefix={undefined}
+        suffix={undefined}
+        defaultValue="1234"
+      />
+    );
+
+    expect(screen.getByRole('textbox')).toHaveValue('1,234');
+
+    userEvent.type(screen.getByRole('textbox'), '56');
+
+    expect(screen.getByRole('textbox')).toHaveValue('123,456');
+
+    userEvent.type(screen.getByRole('textbox'), '{backspace}{backspace}');
+
+    expect(screen.getByRole('textbox')).toHaveValue('1,234');
+  });
 });


### PR DESCRIPTION
Resolve https://github.com/cchanxzy/react-currency-input-field/issues/222

Rebased @felixfbecker's [pull request](https://github.com/cchanxzy/react-currency-input-field/pull/296) on `main` and added a test case as requested in https://github.com/cchanxzy/react-currency-input-field/pull/296#issuecomment-1793756970.