### PR TITLE
fix(esm): bundle ESM/CJS builds to avoid Node ESM resolution issues in SSR

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -1,31 +1,26 @@
 import * as esbuild from 'esbuild';
-import { glob } from 'glob';
-
-const files = glob.sync('src/**/*.{ts,tsx}', {
-  ignore: ['src/examples/**', 'src/**/__tests__/**', 'src/**/*.spec.{ts,tsx}'],
-});
 
 // Exports ESM
 esbuild.build({
-  entryPoints: files,
-  outdir: 'dist/esm',
-  bundle: false,
+  entryPoints: ['src/index.ts'],
+  outfile: 'dist/esm/index.js',
+  bundle: true,
   sourcemap: true,
-  splitting: true,
-  platform: 'browser',
+  platform: 'neutral',
   format: 'esm',
   target: ['esnext'],
   minify: true,
+  external: ['react'],
 });
 
-// Exports CJS
 esbuild.build({
-  entryPoints: files,
-  outdir: 'dist/cjs',
-  bundle: false,
+  entryPoints: ['src/index.ts'],
+  outfile: 'dist/cjs/index.js',
+  bundle: true,
   sourcemap: true,
-  platform: 'browser',
+  platform: 'neutral',
   format: 'cjs',
   target: ['esnext'],
   minify: true,
+  external: ['react'],
 });


### PR DESCRIPTION
## Summary
This PR updates the build to emit single-file bundles for both ESM and CJS. It removes extensionless internal imports from the ESM output that break SSR under Node’s ESM resolver.

The published ESM entry `dist/esm/index.js` previously referenced internal files using extensionless relative imports (e.g., `./components/CurrencyInput`). When a dev SSR tool (e.g., Vite with React Router) externalizes the package, Node tries to resolve those imports directly and fails because Node ESM requires explicit file extensions.

This surfaced as: “Cannot find module .../dist/esm/components/CurrencyInput imported from .../dist/esm/index.js”.

## Solution

- Switch to single-file bundles for both ESM and CJS:
- ESM: entryPoints: ['src/index.ts'], outfile: 'dist/esm/index.js', bundle: true, format: 'esm', platform: 'neutral', external: ['react'], minify: true.
- CJS: outfile: 'dist/cjs/index.js', bundle: true, format: 'cjs', platform: 'neutral', external: ['react'], minify: true.
- This removes all internal relative imports from the ESM entry, so Node never needs to resolve extensionless paths.
- Bundle size impact is negligible. 

## Minimal Reproduction

- Create a new React Router SSR app: `npx create react-router@latest`
- Install the current package:  `pnpm add react-currency-input-field@4.0.1`
- Add to the welcome/home route:  `import CurrencyInput from 'react-currency-input-field'`
- Add a `<CurrencyImport>` component somewhere on the page
- Run dev SSR (React Router + Vite):   `pnpm dev`
- Load page and observe error:
- Build this branch of the library, install the built package (via file/tarball or pnpm link) into the same minimal app, and run dev again. The page renders without SSR errors.