### PR TITLE
docs: update README and improve type documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,32 +68,36 @@ import CurrencyInput from 'react-currency-input-field';
 />;
 ```
 
-Have a look in [`src/examples`](https://github.com/cchanxzy/react-currency-input-field/tree/main/src/examples) for more examples on implementing and validation.
+See [`src/examples`](https://github.com/cchanxzy/react-currency-input-field/tree/main/src/examples) for more patterns covering implementation details and validation helpers.
 
 ## Props
 
-| Name                                               | Type       | Default        | Description                                                                                    |
-| -------------------------------------------------- | ---------- | -------------- | ---------------------------------------------------------------------------------------------- |
-| allowDecimals                                      | `boolean`  | `true`         | Allow decimals                                                                                 |
-| allowNegativeValue                                 | `boolean`  | `true`         | Allow user to enter negative value                                                             |
-| defaultValue                                       | `number`   |                | Default value                                                                                  |
-| value                                              | `number`   |                | Programmatically set the value                                                                 |
-| [onValueChange](#onvaluechange)                    | `function` |                | Handle change in value                                                                         |
-| placeholder                                        | `string`   |                | Placeholder if no value                                                                        |
-| [decimalsLimit](#decimal-scale-and-decimals-limit) | `number`   | `2`            | Limit length of decimals allowed                                                               |
-| [decimalScale](#decimal-scale-and-decimals-limit)  | `number`   |                | Specify decimal scale for padding/trimming eg. 1.5 -> 1.50 or 1.234 -> 1.23 if decimal scale 2 |
-| [fixedDecimalLength](#fixed-decimal-length)        | `number`   |                | Value will always have the specified length of decimals                                        |
-| [prefix](#prefix-and-suffix)                       | `string`   |                | Include a prefix eg. £ or \$                                                                   |
-| [suffix](#prefix-and-suffix)                       | `string`   |                | Include a suffix eg. € or %                                                                    |
-| [decimalSeparator](#separators)                    | `string`   | locale default | Separator between integer part and fractional part of value                                    |
-| [groupSeparator](#separators)                      | `string`   | locale default | Separator between thousand, million and billion                                                |
-| [intlConfig](#intl-locale-config)                  | `object`   |                | International locale config                                                                    |
-| disabled                                           | `boolean`  | `false`        | Disabled                                                                                       |
-| disableAbbreviations                               | `boolean`  | `false`        | Disable abbreviations eg. 1k -> 1,000, 2m -> 2,000,000                                         |
-| [disableGroupSeparators](#separators)              | `boolean`  | `false`        | Disable auto adding the group separator between values, eg. 1000 -> 1,000                      |
-| maxLength                                          | `number`   |                | Maximum characters the user can enter                                                          |
-| step                                               | `number`   |                | Incremental value change on arrow down and arrow up key press                                  |
-| transformRawValue                                  | `function` |                | Transform the raw value from the input before parsing. Needs to return `string`.               |
+| Name                                               | Type                | Default        | Description                                                                                                  |
+| -------------------------------------------------- | ------------------- | -------------- | ------------------------------------------------------------------------------------------------------------ |
+| allowDecimals                                      | `boolean`           | `true`         | Allow entering decimal values.                                                                               |
+| allowNegativeValue                                 | `boolean`           | `true`         | Allow the user to enter negative numbers.                                                                    |
+| className                                          | `string`            |                | Additional CSS class names for the rendered input.                                                           |
+| customInput                                        | `React.ElementType` | `input`        | Render a custom component instead of the native `input`.                                                     |
+| [decimalsLimit](#decimal-scale-and-decimals-limit) | `number`            | `2`            | Maximum number of fractional digits the user can type.                                                       |
+| [decimalScale](#decimal-scale-and-decimals-limit)  | `number`            |                | Pads or trims decimals on blur to the specified length.                                                      |
+| [decimalSeparator](#separators)                    | `string`            | locale default | Character used to separate the integer and fractional parts. Cannot be numeric or match the group separator. |
+| defaultValue                                       | `number \| string`  |                | Initial value when the component is uncontrolled.                                                            |
+| value                                              | `number \| string`  |                | Controlled value supplied by the parent component.                                                           |
+| disabled                                           | `boolean`           | `false`        | Disable user interaction.                                                                                    |
+| disableAbbreviations                               | `boolean`           | `false`        | Disable shorthand parsing (`1k`, `2m`, `3b`, etc.).                                                          |
+| [disableGroupSeparators](#separators)              | `boolean`           | `false`        | Prevent automatic insertion of group separators (e.g. keep `1000` instead of `1,000`).                       |
+| [fixedDecimalLength](#fixed-decimal-length)        | `number`            |                | Forces the value to always display with the specified number of decimals on blur.                            |
+| formatValueOnBlur                                  | `boolean`           | `true`         | When set to `false`, the `onValueChange` will not be called on `blur` events.                                |
+| [groupSeparator](#separators)                      | `string`            | locale default | Character used to group thousands. Cannot be numeric.                                                        |
+| id                                                 | `string`            |                | Forwarded to the rendered input element.                                                                     |
+| [intlConfig](#intl-locale-config)                  | `IntlConfig`        |                | Locale configuration for `Intl.NumberFormat` (locale, currency, style).                                      |
+| maxLength                                          | `number`            |                | Maximum number of characters (excluding the negative sign) the user can enter.                               |
+| [onValueChange](#onvaluechange)                    | `function`          |                | Handler fired whenever the parsed value changes.                                                             |
+| placeholder                                        | `string`            |                | Displayed when there is no value.                                                                            |
+| [prefix](#prefix-and-suffix)                       | `string`            |                | String added before the value (e.g. `£`, `$`). Overrides locale-derived prefixes.                            |
+| [suffix](#prefix-and-suffix)                       | `string`            |                | String added after the value (e.g. `%`, `€`). Overrides locale-derived suffixes.                             |
+| step                                               | `number`            |                | Increment applied when pressing `ArrowUp` / `ArrowDown`.                                                     |
+| transformRawValue                                  | `function`          |                | Intercept and adjust the raw input string before parsing. Must return a string.                              |
 
 ### onValueChange
 
@@ -106,6 +110,8 @@ onValueChange = (value, name, values) => void;
 #### value
 
 `value` will give you the value in a string format, without the prefix/suffix/separators.
+
+Useful for displaying the value, but you can use `values.float` if you need the numerical value for calculations.
 
 Example: `£123,456 -> 123456`
 
@@ -131,7 +137,7 @@ Examples:
 - 2.5m = 2,500,000
 - 3.456B = 3,456,000,000
 
-This can be turned off by passing in `disableAbbreviations`.
+This can be turned off by passing in `disableAbbreviations={true}`.
 
 ### Prefix and Suffix
 
@@ -174,11 +180,36 @@ Examples:
 ```javascript
 import CurrencyInput from 'react-currency-input-field';
 
-<CurrencyInput intlConfig={{ locale: 'en-US', currency: 'GBP' }} />;
+// US Dollar
+<CurrencyInput intlConfig={{ locale: 'en-US', currency: 'USD' }} />
 
-<CurrencyInput intlConfig={{ locale: 'ja-JP', currency: 'JPY' }} />;
+// British Pound
+<CurrencyInput intlConfig={{ locale: 'en-GB', currency: 'GBP' }} />
 
-<CurrencyInput intlConfig={{ locale: 'en-IN', currency: 'INR' }} />;
+// Canadian Dollar
+<CurrencyInput intlConfig={{ locale: 'en-CA', currency: 'CAD' }} />
+
+// Australian Dollar
+<CurrencyInput intlConfig={{ locale: 'en-AU', currency: 'AUD' }} />
+
+// Japanese Yen
+<CurrencyInput intlConfig={{ locale: 'ja-JP', currency: 'JPY' }} />
+
+// Chinese Yuan
+<CurrencyInput intlConfig={{ locale: 'zh-CN', currency: 'CNY' }} />
+
+// Euro (Germany)
+<CurrencyInput intlConfig={{ locale: 'de-DE', currency: 'EUR' }} />
+
+// Euro (France)
+<CurrencyInput intlConfig={{ locale: 'fr-FR', currency: 'EUR' }} />
+
+// Indian Rupee
+<CurrencyInput intlConfig={{ locale: 'hi-IN', currency: 'INR' }} />
+
+// Brazilian Real
+<CurrencyInput intlConfig={{ locale: 'pt-BR', currency: 'BRL' }} />
+
 ```
 
 `locale` should be a [BCP 47 language tag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation), such as "en-US" or "en-IN".
@@ -245,7 +276,7 @@ console.log(formattedValue1);
 // Format using intl locale config
 const formattedValue2 = formatValue({
   value: '500000',
-  intlConfig: { locale: 'en-IN', currency: 'INR' },
+  intlConfig: { locale: 'hi-IN', currency: 'INR' },
 });
 
 console.log(formattedValue2);

--- a/src/components/CurrencyInputProps.ts
+++ b/src/components/CurrencyInputProps.ts
@@ -3,29 +3,29 @@ import React, { ElementType } from 'react';
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
 
 /**
- * Value in different formats
+ * Value in different formats provided to `onValueChange`.
  *
- * @experimental
+ * See {@link https://www.npmjs.com/package/react-currency-input-field#onvaluechange}
  */
 export type CurrencyInputOnChangeValues = {
   /**
    * Value as float or null if empty
    *
    * Example:
-   *   "1.99" > 1.99
-   *   "" > null
+   *   - "1.99" > 1.99
+   *   - "" > null
    */
   float: number | null;
 
   /**
    * Value after applying formatting
    *
-   * Example: "1000000" > "1,000,0000"
+   * Example: "1000000" > "1,000,000"
    */
   formatted: string;
 
   /**
-   * Non formatted value as string
+   * Non formatted value as string (same as first argument in `onValueChange`)
    */
   value: string;
 };
@@ -38,66 +38,89 @@ export type CurrencyInputProps = Overwrite<
   React.ComponentPropsWithRef<'input'>,
   {
     /**
-     * Allow decimals
+     * Allow decimals to be entered.
      *
-     * Default = true
+     * Default: `true`
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#props}
      */
     allowDecimals?: boolean;
 
     /**
-     * Allow user to enter negative value
+     * Allow user to enter a negative value.
      *
-     * Default = true
+     * Default: `true`
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#props}
      */
     allowNegativeValue?: boolean;
 
     /**
      * Component id
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#props}
      */
     id?: string;
 
     /**
-     *  Maximum characters the user can enter
+     * Maximum characters the user can enter
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#props}
      */
     maxLength?: number;
 
     /**
      * Class names
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#props}
      */
     className?: string;
 
     /**
-     * Custom component
+     * Render custom component instead of default `<input/>`.
      *
-     * Default = <input/>
+     * Default: `<input/>`
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#props}
      */
     customInput?: ElementType;
 
     /**
-     * Limit length of decimals allowed
+     * Limit length of decimals allowed.
      *
-     * Default = 2
+     * Prevents typing more than the specified number of decimal places.
+     *
+     * Default: `2`
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#decimal-scale-and-decimals-limit}
      */
     decimalsLimit?: number;
 
     /**
-     * Specify decimal scale for padding/trimming
+     * Specify decimal scale for padding/trimming applied on blur.
      *
      * Example:
-     *   1.5 -> 1.50
-     *   1.234 -> 1.23
+     *   - 1.5 -> 1.50
+     *   - 1.234 -> 1.23
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#decimal-scale-and-decimals-limit}
      */
     decimalScale?: number;
 
     /**
-     * Default value if not passing in value via props
+     * Default value if not passing in value via props.
+     * Accepts a number or a numeric string.
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#props}
      */
     defaultValue?: number | string;
 
     /**
      * Disabled
      *
-     * Default = false
+     * Default: `false`
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#props}
      */
     disabled?: boolean;
 
@@ -108,86 +131,156 @@ export type CurrencyInputProps = Overwrite<
      *   123 -> 1.23
      *
      * Note: This formatting only happens onBlur
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#fixed-decimal-length}
      */
     fixedDecimalLength?: number;
 
     /**
-     * Handle change in value
+     * Handle change in value.
+     *
+     *
+     * Called with `(value, name, values)` where:
+     * - `value` is the plain string without prefix, suffix or separators (eg. "£123,456" -> "123456").
+     * - `name` matches the component `name` prop when provided.
+     * - `values` gives an object with three key values:
+     *   - `float`: Value as float or null if empty. Example: "1.99" > 1.99
+     *   - `formatted`: Value after applying formatting. Example: "1000000" > "1,000,000"
+     *   - `value`: Non formatted value as string, i.e. same as first param.
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#onvaluechange}
      */
     onValueChange?: (
       value: string | undefined,
-      name?: string,
+      name?: string | undefined,
       values?: CurrencyInputOnChangeValues
     ) => void;
 
     /**
      * Placeholder if there is no value
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#props}
      */
     placeholder?: string;
 
     /**
-     * Include a prefix eg. £
+     * Include a prefix eg. `£`
+     *
+     * Passing a prefix overrides intl locale config defaults.
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#prefix-and-suffix}
      */
     prefix?: string;
 
     /**
-     * Include a suffix eg. €
+     * Include a suffix eg. `€`
+     *
+     * Passing a suffix overrides  intl locale config defaults.
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#prefix-and-suffix}
      */
     suffix?: string;
 
     /**
      * Incremental value change on arrow down and arrow up key press
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#props}
      */
     step?: number;
 
     /**
      * Separator between integer part and fractional part of value.
      *
-     * This cannot be a number
+     * Default: `locale default`
+     *
+     * This cannot be a number and must differ from the group separator.
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#separators}
      */
     decimalSeparator?: string;
 
     /**
-     * Separator between thousand, million and billion
+     * Separator between thousand, million and billion.
      *
-     * This cannot be a number
+     * Default: `locale default`
+     *
+     * This cannot be a number.
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#separators}
      */
     groupSeparator?: string;
 
     /**
-     * Disable auto adding separator between values eg. 1000 -> 1,000
+     * Disable auto adding the group separator between values.
      *
-     * Default = false
+     * Default: `false`
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#separators}
      */
     disableGroupSeparators?: boolean;
 
     /**
-     * Disable abbreviations (m, k, b)
+     * Disable abbreviations (m, k, b) so 1k will NOT be formatted to 1,000, 2m will NOT be formatted to 2,000,000 etc...
      *
-     * Default = false
+     * Default: `false`
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#abbreviations}
      */
     disableAbbreviations?: boolean;
 
     /**
-     * International locale config, examples:
-     *   { locale: 'ja-JP', currency: 'JPY' }
-     *   { locale: 'en-IN', currency: 'INR' }
+     * International locale config
      *
-     * Any prefix, groupSeparator or decimalSeparator options passed in
-     * will override Intl Locale config
+     * `locale` should be a BCP 47 language tag and `currency` an ISO 4217 code.
+     *
+     * Any prefix, suffix, groupSeparator or decimalSeparator options passed in
+     * will override Intl locale config.
+     *
+     * Common examples:
+     *  - US Dollar: { locale: 'en-US', currency: 'USD' }
+     *  - British Pound: { locale: 'en-GB', currency: 'GBP' }
+     *  - Canadian Dollar: { locale: 'en-CA', currency: 'CAD' }
+     *  - Australian Dollar: { locale: 'en-AU', currency: 'AUD' }
+     *  - Japanese Yen: { locale: 'ja-JP', currency: 'JPY' }
+     *  - Chinese Yuan: { locale: 'zh-CN', currency: 'CNY' }
+     *  - Euro (Germany): { locale: 'de-DE', currency: 'EUR' }
+     *  - Euro (France): { locale: 'fr-FR', currency: 'EUR' }
+     *  - Indian Rupee: { locale: 'hi-IN', currency: 'INR' }
+     *  - Brazilian Real: { locale: 'pt-BR', currency: 'BRL' }
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#intl-locale-config}
      */
     intlConfig?: IntlConfig;
 
     /**
-     * Transform the raw value form the input before parsing
+     * Transform the raw value from the input before parsing.
+     *
+     * This can be useful for stripping out unwanted characters or formatting the input.
+     *
+     * Must return the transformed string.
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#props}
      */
     transformRawValue?: (rawValue: string) => string;
 
     /**
-     * When set to false, the formatValueOnBlur flag disables the application of the __onValueChange__ function
-     * specifically on blur events. If disabled or set to false, the onValueChange will not trigger on blur.
-     * Default = true
+     * When set to `false`, the `onValueChange` will not be called on `blur` events.
+     *
+     * Default: `true`
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#props}
      */
     formatValueOnBlur?: boolean;
+
+    /**
+     * Current value of the input. This should be a number or a numeric string.
+     *
+     * If provided, the component is controlled.
+     *
+     * If omitted, the component is uncontrolled and manages the value in its own state.
+     *
+     * See {@link https://www.npmjs.com/package/react-currency-input-field#props}
+     */
+    value?: string | number;
   }
 >;

--- a/src/components/__tests__/CurrencyInput-intl-config.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-intl-config.spec.tsx
@@ -18,7 +18,7 @@ describe('<CurrencyInput/> intlConfig', () => {
 
   it('should use intl config settings (en-IN, INR)', () => {
     render(
-      <CurrencyInput id={id} intlConfig={{ locale: 'en-IN', currency: 'INR' }} value="500000" />
+      <CurrencyInput id={id} intlConfig={{ locale: 'hi-IN', currency: 'INR' }} value="500000" />
     );
 
     expect(screen.getByRole('textbox')).toHaveValue('₹5,00,000');
@@ -94,7 +94,7 @@ describe('<CurrencyInput/> intlConfig', () => {
       render(
         <CurrencyInput
           id={id}
-          intlConfig={{ locale: 'en-IN', currency: 'INR' }}
+          intlConfig={{ locale: 'hi-IN', currency: 'INR' }}
           onValueChange={onValueChangeSpy}
         />
       );

--- a/src/components/utils/__tests__/formatValue.spec.ts
+++ b/src/components/utils/__tests__/formatValue.spec.ts
@@ -272,7 +272,7 @@ describe('formatValue', () => {
       expect(
         formatValue({
           value: '-500000',
-          intlConfig: { locale: 'en-IN', currency: 'INR' },
+          intlConfig: { locale: 'hi-IN', currency: 'INR' },
         })
       ).toEqual('-₹5,00,000');
 
@@ -303,7 +303,7 @@ describe('formatValue', () => {
       expect(
         formatValue({
           value: '-500000',
-          intlConfig: { locale: 'en-IN' },
+          intlConfig: { locale: 'hi-IN' },
         })
       ).toEqual('-5,00,000');
 
@@ -383,7 +383,7 @@ describe('formatValue', () => {
       expect(
         formatValue({
           value: '-123456',
-          intlConfig: { locale: 'en-IN', currency: 'INR' },
+          intlConfig: { locale: 'hi-IN', currency: 'INR' },
           groupSeparator: '-',
         })
       ).toEqual('-₹1-23-456');

--- a/src/examples/Example3.tsx
+++ b/src/examples/Example3.tsx
@@ -19,7 +19,7 @@ const options: ReadonlyArray<CurrencyInputProps['intlConfig']> = [
     currency: 'JPY',
   },
   {
-    locale: 'en-IN',
+    locale: 'hi-IN',
     currency: 'INR',
   },
 ];


### PR DESCRIPTION
It's been a while since I've updated the documentation, so this PR is to update the prop descriptions and give more examples so that it is easier to use.

Example of improved type definition documentation:

<img width="1428" height="584" alt="image" src="https://github.com/user-attachments/assets/6afd9521-6f79-4031-a396-ac1f9934ca5e" />
