### PR TITLE
ci: add experimental branch to semantic release

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -32,5 +32,6 @@
       'next-major',
       { name: 'beta', prerelease: true },
       { name: 'alpha', prerelease: true },
+      { 'name': 'experimental', 'prerelease': 'experimental' },
     ],
 }


### PR DESCRIPTION
# Description

Adding `experimental` branch to semantic release settings so that I can test some build config changes without polluting main.

The `experimental` branch will be for testing purposes only.