### PR TITLE
fix: get group separator in locales that omit group separator for 4 digits

### DIFF
--- a/src/components/utils/__tests__/getLocaleConfig.spec.ts
+++ b/src/components/utils/__tests__/getLocaleConfig.spec.ts
@@ -30,4 +30,14 @@ describe('getLocaleConfig', () => {
       suffix: '',
     });
   });
+
+  it('should include group separator for locales that skip grouping 4-digit numbers', () => {
+    expect(getLocaleConfig({ locale: 'pt-PT' })).toStrictEqual({
+      currencySymbol: '',
+      decimalSeparator: ',',
+      groupSeparator: '\u00a0',
+      prefix: '',
+      suffix: '',
+    });
+  });
 });

--- a/src/components/utils/getLocaleConfig.ts
+++ b/src/components/utils/getLocaleConfig.ts
@@ -28,7 +28,7 @@ export const getLocaleConfig = (intlConfig?: IntlConfig): LocaleConfig => {
       })
     : new Intl.NumberFormat();
 
-  return numberFormatter.formatToParts(1000.1).reduce((prev, curr, i): LocaleConfig => {
+  return numberFormatter.formatToParts(10000.1).reduce((prev, curr, i): LocaleConfig => {
     if (curr.type === 'currency') {
       if (i === 0) {
         return { ...prev, currencySymbol: curr.value, prefix: curr.value };


### PR DESCRIPTION
In some locales, when using a 4 digit number (such as '1000') the group separator will be omited, only being added if a 5th digit is added. This meant that the group separator was not correctly identified for locales such as `pt-PT`.

This change updates the logic to get the locale to use more than 4 digits, to account for those scenarios.

Fixes https://github.com/cchanxzy/react-currency-input-field/issues/410