### PR TITLE
fix(package): exclude test files and examples from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "sideEffects": false,
   "files": [
     "dist/**/*",
-    "src/**/*"
+    "src/components/**/*.ts",
+    "src/components/**/*.tsx",
+    "!src/components/**/__tests__/**",
+    "src/index.ts"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
# Trim published npm package files

## Summary

- Tighten the `files` field in `package.json` to exclude test files and the examples app from the published package

## Why

The previous `src/**/*` glob was including everything under `src/` — test files, snapshots, and the examples app — none of which are useful to consumers. This unnecessarily inflated the package.

## Result

|               | Before | After  |
| ------------- | ------ | ------ |
| Unpacked size | 274 kB | 167 kB |
| Total files   | 78     | 42     |

## What's included

- `dist/**/*` — ESM/CJS bundles, source maps, and type declarations
- `src/components/**/*.ts` / `*.tsx` — component source files (useful for source map debugging)
- `src/index.ts` — public entry point
- Tests, snapshots, and `src/examples/` are excluded
