### PR TITLE
fix(types): make name and values required in onValueChange callback

### DIFF
--- a/src/components/CurrencyInputProps.ts
+++ b/src/components/CurrencyInputProps.ts
@@ -152,8 +152,8 @@ export type CurrencyInputProps = Overwrite<
      */
     onValueChange?: (
       value: string | undefined,
-      name?: string | undefined,
-      values?: CurrencyInputOnChangeValues
+      name: string | undefined,
+      values: CurrencyInputOnChangeValues
     ) => void;
 
     /**


### PR DESCRIPTION
## Summary

`onValueChange` types `name` and `values` as optional (`?`), but every call site in the source always passes all three arguments — including the empty/clear case, which passes `undefined` for `value` and `{ float: null, formatted: "", value: "" }` for `values`. There is no code path where `onValueChange` is called without all three arguments.

### What changed

Removed the `?` from `name` and `values` in the `onValueChange` callback signature so the types accurately reflect runtime behavior:

```ts
// Before
onValueChange?: (
  value: string | undefined,
  name?: string | undefined,
  values?: CurrencyInputOnChangeValues
) => void;

// After
onValueChange?: (
  value: string | undefined,
  name: string | undefined,
  values: CurrencyInputOnChangeValues
) => void;
```

### Why this is not a breaking change

The optional markers were never solving a real problem. JavaScript functions naturally accept fewer arguments than their signature declares — a callback defined as (value) => doSomething(value) can always be passed three arguments without issue. TypeScript reflects this correctly: a function typed as (value: string | undefined) => void is assignable to a callback that passes three arguments, with no changes needed on the consumer side.

Consumers who don't use name or values can continue to omit them from their handler signature. Consumers who do use them no longer need to defensively guard against undefined on arguments that are always present.

Closes #426