### PR TITLE
fix(format-value): keep trailing zero decimals when prefix contains the decimal separator

### DIFF
--- a/src/components/__tests__/CurrencyInput-decimals.spec.tsx
+++ b/src/components/__tests__/CurrencyInput-decimals.spec.tsx
@@ -122,6 +122,32 @@ describe('<CurrencyInput/> decimals', () => {
     });
   });
 
+  it('should keep trailing zero decimals when prefix contains the decimal separator', () => {
+    render(<CurrencyInput prefix="kr." onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '1.0');
+
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1.0', undefined, {
+      float: 1,
+      formatted: 'kr.1.0',
+      value: '1.0',
+    });
+
+    expect(screen.getByRole('textbox')).toHaveValue('kr.1.0');
+  });
+
+  it('should keep decimals while typing when prefix contains the decimal separator', () => {
+    render(<CurrencyInput prefix="kr." onValueChange={onValueChangeSpy} />);
+    userEvent.type(screen.getByRole('textbox'), '1000.05');
+
+    expect(onValueChangeSpy).toHaveBeenLastCalledWith('1000.05', undefined, {
+      float: 1000.05,
+      formatted: 'kr.1,000.05',
+      value: '1000.05',
+    });
+
+    expect(screen.getByRole('textbox')).toHaveValue('kr.1,000.05');
+  });
+
   it('should handle starting with decimal separator that is non period', () => {
     render(
       <CurrencyInput

--- a/src/components/utils/__tests__/formatValue.spec.ts
+++ b/src/components/utils/__tests__/formatValue.spec.ts
@@ -203,6 +203,68 @@ describe('formatValue', () => {
     ).toEqual('$30');
   });
 
+  it('should keep trailing zero decimals when prefix contains the decimal separator', () => {
+    expect(
+      formatValue({
+        value: '1.0',
+        prefix: 'kr.',
+        decimalSeparator: '.',
+        groupSeparator: ',',
+      })
+    ).toEqual('kr.1.0');
+
+    expect(
+      formatValue({
+        value: '1.0',
+        prefix: 'د.إ',
+        decimalSeparator: '.',
+        groupSeparator: ',',
+      })
+    ).toEqual('د.إ1.0');
+  });
+
+  it('should keep decimals when prefix contains the decimal separator and value has decimals', () => {
+    expect(
+      formatValue({
+        value: '1000.05',
+        prefix: 'kr.',
+        decimalSeparator: '.',
+        groupSeparator: ',',
+      })
+    ).toEqual('kr.1,000.05');
+  });
+
+  it('should handle negative value when prefix contains the decimal separator', () => {
+    expect(
+      formatValue({
+        value: '-1.0',
+        prefix: 'kr.',
+        decimalSeparator: '.',
+        groupSeparator: ',',
+      })
+    ).toEqual('-kr.1.0');
+  });
+
+  it('should handle prefix equal to the decimal separator', () => {
+    expect(
+      formatValue({
+        value: '1.05',
+        prefix: '.',
+        decimalSeparator: '.',
+        groupSeparator: ',',
+      })
+    ).toEqual('.1.05');
+
+    expect(
+      formatValue({
+        value: '1.0',
+        prefix: '.',
+        decimalSeparator: '.',
+        groupSeparator: ',',
+      })
+    ).toEqual('.1.0');
+  });
+
   it('should prefix decimal values correctly with zero', () => {
     expect(
       formatValue({

--- a/src/components/utils/formatValue.ts
+++ b/src/components/utils/formatValue.ts
@@ -65,7 +65,12 @@ export const formatValue = (options: FormatValueOptions): string => {
 
   // Keep original decimal padding if no decimalScale
   if (decimalScale === undefined && decimals && decimalSeparator) {
-    if (formatted.includes(decimalSeparator)) {
+    // The prefix itself may contain the decimal separator (e.g. 'kr.' or 'د.إ'),
+    // so only check the formatted value excluding the prefix. Only the first
+    // occurrence is removed: it is always the prefix, as at most a minus sign
+    // can precede it, and later occurrences may belong to the number itself
+    const formattedWithoutPrefix = prefix ? formatted.replace(prefix, '') : formatted;
+    if (formattedWithoutPrefix.includes(decimalSeparator)) {
       formatted = formatted.replace(
         RegExp(`(\\d+)(${escapeRegExp(decimalSeparator)})(\\d+)`, 'g'),
         `$1$2${decimals}`


### PR DESCRIPTION
## Bug

When `prefix` contains the decimal separator character - real currencies do this (Danish krone `kr.`, UAE dirham `د.إ`) - trailing-zero decimals were eaten on every keystroke:

​```ts
formatValue({ value: '1.0', prefix: 'kr.', decimalSeparator: '.', groupSeparator: ',' })
// actual: "kr.1"   expected: "kr.1.0"
​```

Interactively this made some amounts untypeable: entering `1000.05` rendered `kr.10,005`, because the intermediate keystroke `1000.0` lost its `.0` and the final `5` landed directly after `1000`.

## Root cause

In the "keep original decimal padding" block of `formatValue`, `formatted.includes(decimalSeparator)` was satisfied by the prefix's own `.`, sending the code down the replace branch whose `(\d+)(\.)(\d+)` regex found nothing to restore - so the trailing-zero decimals were never re-appended.

## Fix

Strip the first occurrence of the prefix from `formatted` before checking for the decimal separator. Only the first occurrence is removed because it is always the prefix itself (at most a minus sign precedes it), while later occurrences may belong to the number.

## Tests

- Unit: `kr.`/`د.إ` trailing zeros, `kr.1,000.05` replace-branch guard, negative values, and a prefix equal to the separator itself.
- Component: typing `1.0` and `1000.05` with `prefix="kr."` (the exact broken keystroke sequences).